### PR TITLE
added context management methods to Dataset & is_dicom function

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -80,6 +80,12 @@ class Dataset(dict):
         self._parent_encoding = kwargs.get('parent_encoding', default_encoding)
         dict.__init__(self, *args)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
     def add(self, data_element):
         """Equivalent to dataset[data_element.tag] = data_element."""
         self[data_element.tag] = data_element
@@ -698,3 +704,4 @@ class FileDataset(Dataset):
         if stat_available and self.filename and os.path.exists(self.filename):
             statinfo = stat(self.filename)
             self.timestamp = statinfo.st_mtime
+

--- a/pydicom/misc.py
+++ b/pydicom/misc.py
@@ -4,6 +4,7 @@
 # This file is part of pydicom, released under a modified MIT license.
 #    See the file license.txt included with this distribution, also
 #    available at https://github.com/darcymason/pydicom
+import os.path
 
 _size_factors = dict(KB=1024, MB=1024 * 1024, GB=1024 * 1024 * 1024)
 
@@ -20,3 +21,32 @@ def size_in_bytes(expr):
             return val
         else:
             raise ValueError("Unable to parse length with unit '{0:s}'".format(unit))
+
+def is_dicom(file):
+    """Boolean specifying if file is a proper DICOM file.
+
+    This function is a pared down version of read_preamble meant for a fast return.
+    The file is read for a proper preamble ('DICM'), returning True if so,
+    and False otherwise. This is a conservative approach.
+
+    Parameters
+    ----------
+    file : str
+        The path to the file.
+
+    See Also
+    --------
+    filereader.read_preamble
+    filereader.read_partial
+    """
+    # TODO: add a force parameter maybe?
+    if not os.path.isfile(file):
+        raise IOError("File passed was not a valid file")
+        # TODO: error is only in Py3; what's a better Py2/3 error?
+    fp = open(file, 'rb')
+    preamble = fp.read(0x80)
+    magic = fp.read(4)
+    if magic == b"DICM":
+        return True
+    else:
+        return False

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,24 @@
+"""Test the miscellaneous functions."""
+
+import unittest
+import os.path as osp
+
+from pydicom.misc import is_dicom
+
+test_file = osp.join(osp.dirname(osp.abspath(__file__)), 'test_files', 'CT_small.dcm')
+
+class Test_Misc(unittest.TestCase):
+
+    def test_is_dicom(self):
+        """Test the is_dicom function."""
+        invalid_file = test_file.replace('CT_', 'CT')  # invalid file
+        notdicom_file = osp.abspath(__file__)  # use own file
+
+        # valid file returns True
+        self.assertTrue(is_dicom(test_file))
+
+        # return false for real file but not dicom
+        self.assertFalse(is_dicom(notdicom_file))
+
+        # test invalid path
+        self.assertRaises(IOError, is_dicom, invalid_file)


### PR DESCRIPTION
Why? So a user can do things like this:
``with pydicom.read_file('mydicom.dcm') as dcm:`` which will elegantly handle object destruction (Dataset). This is useful for large dicom files or when a user only wants the information of a few tags. I should add that this adds context to the returned object, not the file object that was passed. I'm unsure of behavior for a file object passed with such behavior (I never use it that way).

Why Dataset? 
It took me a while to figure out exactly what needs to happen, but in the end, whatever ``object`` gets returned in the ``with`` statement has to have the ``__enter__()`` and ``__exit__()`` methods, which, in the case of read_file, read_partial, is a Dataset. This could also be put into FileDataset; I'm not sure if one is preferable or not. I found PMOTW helpful: http://pymotw.com/2/contextlib/