### PR TITLE
Fixes issue #143

### DIFF
--- a/pydicom/config.py
+++ b/pydicom/config.py
@@ -54,6 +54,11 @@ enforce_valid_values = True
 that are longer than 16 characters; IS strings outside the allowed range.
 """
 
+datetime_conversion = False
+"""Set datetime_conversion to convert DA, DT and TM data elements to
+datetime.date, datetime.datetime and datetime.time respectively. Default: False
+"""
+
 
 # Logging system and debug function to change logging level
 logger = logging.getLogger('pydicom')

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -21,6 +21,7 @@ from pydicom.tag import Tag
 
 from pydicom.uid import UID
 import pydicom.valuerep  # don't import DS directly as can be changed by config
+import pydicom.config
 from pydicom.compat import in_py2
 
 if not in_py2:
@@ -160,8 +161,14 @@ class DataElement(object):
         """Take the value and convert to number, etc if possible"""
         if self.VR == 'IS':
             return pydicom.valuerep.IS(val)
+        elif self.VR == 'DA' and pydicom.config.datetime_conversion:
+            return pydicom.valuerep.DA(val)
         elif self.VR == 'DS':
             return pydicom.valuerep.DS(val)
+        elif self.VR == 'DT' and pydicom.config.datetime_conversion:
+            return pydicom.valuerep.DT(val)
+        elif self.VR == 'TM' and pydicom.config.datetime_conversion:
+            return pydicom.valuerep.TM(val)
         elif self.VR == "UI":
             return UID(val)
         elif not in_py2 and self.VR == "PN":

--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -100,7 +100,7 @@ def write_string(fp, data_element, padding=' ', encoding=default_encoding):
     """Write a single or multivalued string."""
     val = multi_string(data_element.value)
     if len(val) % 2 != 0:
-        val = val + padding   # pad to even length
+        val = val + padding  # pad to even length
 
     if isinstance(val, compat.text_type):
         val = val.encode(encoding)
@@ -119,12 +119,72 @@ def write_number_string(fp, data_element, padding=' '):
     else:
         val = val.original_string if hasattr(val, 'original_string') else str(val)
     if len(val) % 2 != 0:
-        val = val + padding   # pad to even length
+        val = val + padding  # pad to even length
 
     if not in_py2:
         val = bytes(val, default_encoding)
 
     fp.write(val)
+
+
+def write_DA(fp, data_element, padding=' '):
+    val = data_element.value
+    if isinstance(val, (str, unicode)):
+        write_string(fp, data_element, padding)
+    else:
+        if hasattr(val, 'original_string'):
+            val = val.original_string
+        else:
+            val = val.strftime("%Y%m%d")
+        if len(val) % 2 != 0:
+            val = val + padding  # pad to even length
+
+        if isinstance(val, unicode):
+            val = val.encode(default_encoding)
+
+        fp.write(val)
+
+
+def write_DT(fp, data_element, padding=' '):
+    val = data_element.value
+    if isinstance(val, (str, unicode)):
+        write_string(fp, data_element, padding)
+    else:
+        if hasattr(val, 'original_string'):
+            val = val.original_string
+        else:
+            if val.microsecond > 0:
+                val = val.strftime("%Y%m%d%H%M%S.%f%z")
+            else:
+                val = val.strftime("%Y%m%d%H%M%S%z")
+        if len(val) % 2 != 0:
+            val = val + padding  # pad to even length
+
+        if isinstance(val, unicode):
+            val = val.encode(default_encoding)
+
+        fp.write(val)
+
+
+def write_TM(fp, data_element, padding=' '):
+    val = data_element.value
+    if isinstance(val, (str, unicode)):
+        write_string(fp, data_element, padding)
+    else:
+        if hasattr(val, 'original_string'):
+            val = val.original_string
+        else:
+            if val.microsecond > 0:
+                val = val.strftime("%H%M%S.%f")
+            else:
+                val = val.strftime("%H%M%S")
+        if len(val) % 2 != 0:
+            val = val + padding  # pad to even length
+
+        if isinstance(val, unicode):
+            val = val.encode(default_encoding)
+
+        fp.write(val)
 
 
 def write_data_element(fp, data_element, encoding=default_encoding):
@@ -392,8 +452,8 @@ writers = {'UL': (write_numbers, 'L'),
            'OB': (write_OBvalue, None),
            'UI': (write_UI, None),
            'SH': (write_string, None),
-           'DA': (write_string, None),
-           'TM': (write_string, None),
+           'DA': (write_DA, None),
+           'TM': (write_TM, None),
            'CS': (write_string, None),
            'PN': (write_PN, None),
            'LO': (write_string, None),
@@ -414,6 +474,6 @@ writers = {'UL': (write_numbers, 'L'),
            'OB/OW': (write_OBvalue, None),
            'OB or OW': (write_OBvalue, None),
            'OW or OB': (write_OBvalue, None),
-           'DT': (write_string, None),
+           'DT': (write_DT, None),
            'UT': (write_string, None),
            }  # note OW/OB depends on other items, which we don't know at write time

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -13,9 +13,9 @@ from pydicom import compat
 # Because DS can be based on float or decimal, import whole module, not DS
 #    directly, so it can be changed in user code and be updated here also
 import pydicom.valuerep
-from pydicom.valuerep import MultiString
+from pydicom.valuerep import MultiString, DA, DT, TM
 
-from pydicom.config import logger
+from pydicom.config import logger, datetime_conversion
 
 if not in_py2:
     from pydicom.valuerep import PersonName3 as PersonName
@@ -51,6 +51,19 @@ def convert_ATvalue(byte_string, is_little_endian, struct_format=None):
                             for x in range(0, length, 4)])
 
 
+def convert_DA_string(byte_string, is_little_endian, struct_format=None):
+    """Read and return a DA value"""
+    if datetime_conversion:
+        if not in_py2:
+            byte_string = byte_string.decode(encoding)
+        length = len(byte_string)
+        if length != 8:
+            logger.warn("Expected length to be 8, got length %d", length)
+        return DA(byte_string)
+    else:
+        return convert_string(byte_string, is_little_endian, struct_format)
+
+
 def convert_DS_string(byte_string, is_little_endian, struct_format=None):
     """Read and return a DS value or list of values"""
     if not in_py2:
@@ -58,6 +71,19 @@ def convert_DS_string(byte_string, is_little_endian, struct_format=None):
     # Below, go directly to DS class instance rather than factory DS,
     # but need to ensure last string doesn't have blank padding (use strip())
     return MultiString(byte_string.strip(), valtype=pydicom.valuerep.DSclass)
+
+
+def convert_DT_string(byte_string, is_little_endian, struct_format=None):
+    """Read and return a DT value"""
+    if datetime_conversion:
+        if not in_py2:
+            byte_string = byte_string.decode(encoding)
+        length = len(byte_string)
+        if length < 14 or length > 26:
+            logger.warn("Expected length between 14 and 26, got length %d", length)
+        return DT(byte_string)
+    else:
+        return convert_string(byte_string, is_little_endian, struct_format)
 
 
 def convert_IS_string(byte_string, is_little_endian, struct_format=None):
@@ -149,6 +175,19 @@ def convert_SQ(byte_string, is_implicit_VR, is_little_endian,
     return seq
 
 
+def convert_TM_string(byte_string, is_little_endian, struct_format=None):
+    """Read and return a TM value"""
+    if datetime_conversion:
+        if not in_py2:
+            byte_string = byte_string.decode(encoding)
+        length = len(byte_string)
+        if length < 2 or length > 16:
+            logger.warn("Expected length between 2 and 16, got length %d", length)
+        return TM(byte_string)
+    else:
+        return convert_string(byte_string, is_little_endian, struct_format)
+
+
 def convert_UI(byte_string, is_little_endian, struct_format=None):
     """Read and return a UI values or values"""
     # Strip off 0-byte padding for even length (if there)
@@ -213,8 +252,8 @@ converters = {
     'OB': convert_OBvalue,
     'UI': convert_UI,
     'SH': convert_string,
-    'DA': convert_string,
-    'TM': convert_string,
+    'DA': convert_DA_string,
+    'TM': convert_TM_string,
     'CS': convert_string,
     'PN': convert_PN,
     'LO': convert_string,
@@ -236,7 +275,7 @@ converters = {
     'US or OW': convert_OWvalue,
     'US or SS or OW': convert_OWvalue,
     'US\\US or SS\\US': convert_OWvalue,
-    'DT': convert_string,
+    'DT': convert_DT_string,
     'UT': convert_single_string,
 }
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
               'pydicom.util'],
     include_package_data=True,
     version="1.0.0",
+    install_requires=['python-dateutil'],
     zip_safe=False,  # want users to be able to see included examples,tests
     description="Pure python package for DICOM medical file reading and writing",
     author="Darcy Mason and contributors",

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -14,6 +14,7 @@ from pydicom.filewriter import write_data_element
 from pydicom.dataset import Dataset, FileDataset
 from pydicom.sequence import Sequence
 from pydicom.util.hexutil import hex2bytes, bytes2hex
+from pydicom.config import datetime_conversion
 
 # from io import BytesIO
 from pydicom.filebase import DicomBytesIO
@@ -127,6 +128,15 @@ class WriteFileTests(unittest.TestCase):
                         "Item in a list not written correctly to file (VR=DS)")
         if os.path.exists(ct_out):
             os.remove(ct_out)
+
+
+class ScratchWriteDateTimeTests(WriteFileTests):
+    """Simple dataset from scratch, with datetime_conversion enabled"""
+    def setUp(self):
+        datetime_conversion = True
+
+    def tearDown(self):
+        datetime_conversion = False
 
 
 class WriteDataElementTests(unittest.TestCase):

--- a/tests/test_valuerep.py
+++ b/tests/test_valuerep.py
@@ -17,6 +17,9 @@ if not in_py2:
 else:
     from pydicom.valuerep import PersonName, PersonNameUnicode
 
+from datetime import datetime, date, time, timedelta
+from dateutil.tz import tzoffset
+
 
 default_encoding = 'iso8859'
 
@@ -113,6 +116,63 @@ class PersonNametests(unittest.TestCase):
         pn = PersonName3("John^Doe")
         msg = "PersonName3 not equal comparison did not work correctly"
         self.assertFalse(pn != "John^Doe", msg)
+
+
+class DateTimeTests(unittest.TestCase):
+    """Unit tests for DA, DT, TM conversion to datetime objects"""
+
+    def setUp(self):
+        config.datetime_conversion = True
+
+    def tearDown(self):
+        config.datetime_conversion = False
+
+    def testDate(self):
+        """DA conversion to datetime.date ......................................."""
+        dicom_date = "19610804"
+        da = valuerep.DA(dicom_date)
+        datetime_date = date(1961, 8, 4)
+        self.assertEqual(da, datetime_date,
+                         "DA {0} not equal to date {1}".format(dicom_date, datetime_date))
+
+    def testDateTime(self):
+        """DT conversion to datetime.datetime ..................................."""
+        dicom_datetime = "1961"
+        dt = valuerep.DT(dicom_datetime)
+        datetime_datetime = datetime(1961, 1, 1)
+        self.assertEqual(dt, datetime_datetime,
+                         "DT {0} not equal to datetime {1}".format(dicom_datetime, datetime_datetime))
+        dicom_datetime = "19610804"
+        dt = valuerep.DT(dicom_datetime)
+        datetime_datetime = datetime(1961, 8, 4)
+        self.assertEqual(dt, datetime_datetime,
+                         "DT {0} not equal to datetime {1}".format(dicom_datetime, datetime_datetime))
+        dicom_datetime = "19610804192430.123"
+        dt = valuerep.DT(dicom_datetime)
+        datetime_datetime = datetime(1961, 8, 4, 19, 24, 30, 123000)
+        self.assertEqual(dt, datetime_datetime,
+                         "DT {0} not equal to datetime {1}".format(dicom_datetime, datetime_datetime))
+        dicom_datetime = "196108041924-1000"
+        dt = valuerep.DT(dicom_datetime)
+        datetime_datetime = datetime(1961, 8, 4, 19, 24, 0, 0,
+                                     tzoffset(None, -10 * 3600))
+        self.assertEqual(dt, datetime_datetime,
+                         "DT {0} not equal to datetime {1}".format(dicom_datetime, datetime_datetime))
+        self.assertEqual(dt.utcoffset(), timedelta(0, 0, 0, 0, 0, -10),
+                         "DT offset did not compare correctly to timedelta")
+
+    def testTime(self):
+        """TM conversion to datetime.time ......................................."""
+        dicom_time = "2359"
+        tm = valuerep.TM(dicom_time)
+        datetime_time = time(23, 59)
+        self.assertEqual(tm, datetime_time,
+                         "TM {0} not equal to time {1}".format(dicom_time, datetime_time))
+        dicom_time = "235900.123"
+        tm = valuerep.TM(dicom_time)
+        datetime_time = time(23, 59, 00, 123000)
+        self.assertEqual(tm, datetime_time,
+                         "TM {0} not equal to time {1}".format(dicom_time, datetime_time))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Convert DA, DT and TM to datetime objects.

We define specific objects that inherit the datetime objects:
* DA → datetime.date
* DT → datetime.datetime
* TM → datetime.time
When pydicom.config.datetime_conversion is True, we convert DICOM times
and dates to such objects instead of strings.

Appropriate unit tests have been added.