### PR TITLE
BF: do not force unicode names when not supported

### DIFF
--- a/source/dicom/test/test_unicode.py
+++ b/source/dicom/test/test_unicode.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import dicom
+import sys
 import unittest
 
 
@@ -9,6 +10,14 @@ class UnicodeFilenames(unittest.TestCase):
     def testRead(self):
         """Unicode: Can read a file with unicode characters in name................"""
         uni_name = u'test°'
+
+        # verify first that we could encode file name in this environment
+        try:
+            _ = uni_name.encode(sys.getfilesystemencoding())
+        except UnicodeEncodeError:
+            print("SKIP: Environment doesn't support unicode filenames")
+            return
+
         try:
             dicom.read_file(uni_name)
         except UnicodeEncodeError:


### PR DESCRIPTION
The problem comes when e.g. using on systems with LC_ALL=C on Linux -- encoding would fail to that locale.  Alternative resolution could be to force utf8 encoding but wasn't sure if that would be "kosher" so decided just to skip the test (since you don't use any specific additional platform like nose, I just printed "skip" to stay compatible with older unittest's)

```
Index: pydicom-0.9.9/source/dicom/filereader.py
===================================================================
--- pydicom-0.9.9.orig/source/dicom/filereader.py
+++ pydicom-0.9.9/source/dicom/filereader.py
@@ -586,7 +586,9 @@ def read_file(fp, defer_size=None, stop_
         # caller provided a file name; we own the file handle
         caller_owns_file = False
         logger.debug(u"Reading file '{0}'".format(fp))
-        fp = open(fp, 'rb')
+        # yoh: it might encode into file system encoding which might not support
+        # unicode (e.g. C in clean Debian chroots). So force encoding to utf8
+        fp = open(fp.encode('utf8'), 'rb')
 
     if dicom.debugging:
         logger.debug("\n" + "-" * 80)
```