### PR TITLE
Use the `force` to treat invalid values as 'OB' VR.

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -76,9 +76,9 @@ class Dataset(dict):
     """
     indent_chars = "   "
 
-    def __init__(self, *args, force=False, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._parent_encoding = kwargs.get('parent_encoding', default_encoding)
-        self._force = force
+        self._force = kwargs.get('force', False)
         dict.__init__(self, *args)
 
     def __enter__(self):

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -76,8 +76,9 @@ class Dataset(dict):
     """
     indent_chars = "   "
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, force=False, **kwargs):
         self._parent_encoding = kwargs.get('parent_encoding', default_encoding)
+        self._force = force
         dict.__init__(self, *args)
 
     def __enter__(self):
@@ -305,7 +306,8 @@ class Dataset(dict):
             else:
                 character_set = default_encoding
             # Not converted from raw form read from file yet; do so now
-            self[tag] = DataElement_from_raw(data_elem, character_set)
+            self[tag] = DataElement_from_raw(data_elem, character_set,
+                                             force=self._force)
         return dict.__getitem__(self, tag)
 
     def get_item(self, key):
@@ -667,7 +669,7 @@ class Dataset(dict):
 
 class FileDataset(Dataset):
     def __init__(self, filename_or_obj, dataset, preamble=None, file_meta=None,
-                 is_implicit_VR=True, is_little_endian=True):
+                 is_implicit_VR=True, is_little_endian=True, force=False):
         """Initialize a dataset read from a DICOM file.
 
         Parameters
@@ -686,7 +688,7 @@ class FileDataset(Dataset):
         is_little_endian : boolean
             True (default) if little-endian transfer syntax used; False if big-endian.
         """
-        Dataset.__init__(self, dataset)
+        Dataset.__init__(self, dataset, force=force)
         self.preamble = preamble
         self.file_meta = file_meta
         self.is_implicit_VR = is_implicit_VR

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -306,7 +306,8 @@ def data_element_generator(fp, is_implicit_VR, is_little_endian,
 
 
 def read_dataset(fp, is_implicit_VR, is_little_endian, bytelength=None,
-                 stop_when=None, defer_size=None, parent_encoding=default_encoding):
+                 stop_when=None, defer_size=None, force=False,
+                 parent_encoding=default_encoding):
     """Return a Dataset instance containing the next dataset in the file.
 
     Parameters
@@ -360,7 +361,7 @@ def read_dataset(fp, is_implicit_VR, is_little_endian, bytelength=None,
     except NotImplementedError as details:
         logger.error(details)
 
-    return Dataset(raw_data_elements)
+    return Dataset(raw_data_elements, force=force)
 
 
 def read_sequence(fp, is_implicit_VR, is_little_endian, bytelength, encoding,
@@ -638,7 +639,7 @@ def read_partial(fileobj, stop_when=None, defer_size=None, force=False):
                         is_implicit_VR, is_little_endian)
     else:
         return FileDataset(fileobj, dataset, preamble, file_meta_dataset,
-                           is_implicit_VR, is_little_endian)
+                           is_implicit_VR, is_little_endian, force=force)
 
 
 def read_file(fp, defer_size=None, stop_before_pixels=False, force=False):
@@ -662,6 +663,8 @@ def read_file(fp, defer_size=None, stop_before_pixels=False, force=False):
         If False (default), raises an InvalidDicomError if the file
         is not valid DICOM.
         Set to True to force reading even if no header is found.
+        Also force converting tags that contain invalid values, for example
+        an `IS`-type tag with value `12.3`).
 
     Returns
     -------


### PR DESCRIPTION
I need to be able to `force`-read DICOM data sets from the Xoran xCAT-ENT DVT scanner. That device seems to produce invalid dicoms, which nonetheless, I have to handle. In particular, the "Exposure" tag is set  to `"57.6"` but it is stored as an `IS` value representation. This leads to the exception

```
invalid literal for int() with base 10: '57.6'
```

during conversion of the raw value. This is triggered if I just investigate a dataset in IPython for example (because of the pretty printing that already causes the convert).

This PR is just a starting point. Take it as a suggestion. 
I pass `force` all the way down; starting from `read_file`
over `Dataset` to `DataElement_from_raw`. In there, I imagine that the `ValueError` is caught and the fall back is to just treat the field as `'OB'`. 

I am not sure if this is the smartest approach. Suggestions welcome. 
Warning: I haven't run the test suite on this yet.
If you want a sample dcm file from that scanner, let me know.