### PR TITLE
uid: changed generation of uid's

### DIFF
--- a/pydicom/contrib/imViewer_Simple.py
+++ b/pydicom/contrib/imViewer_Simple.py
@@ -255,7 +255,7 @@ class ImFrame(wx.Frame):
             im = PIL.Image.fromarray(image).convert('L')  # Convert mode to L since LUT has only 256 values: http://www.pythonware.com/library/pil/handbook/image.htm
         return im
 
-    def show_file(self, imageFile, fullPath):
+    def show_file(self, fullPath):
         """ Load the DICOM file, make sure it contains at least one
         image, and set it up for display by OnPaint().  ** be
         careful not to pass a unicode string to read_file or it will

--- a/pydicom/contrib/imViewer_Simple.py
+++ b/pydicom/contrib/imViewer_Simple.py
@@ -58,10 +58,10 @@ def MsgDlg(window, string, caption='OFAImage', style=wx.YES_NO | wx.CANCEL):
 class ImFrame(wx.Frame):
     """Class for main window."""
 
-    def __init__(self, parent, title):
+    def __init__(self, parent, title=""):
         """Create the pydicom image example's main frame window."""
 
-        wx.Frame.__init__(self, parent, id=-1, title="", pos=wx.DefaultPosition,
+        wx.Frame.__init__(self, parent, id=-1, title=title, pos=wx.DefaultPosition,
                           size=wx.Size(w=1024, h=768),
                           style=wx.DEFAULT_FRAME_STYLE | wx.SUNKEN_BORDER | wx.CLIP_CHILDREN)
 

--- a/pydicom/contrib/pydicom_series.py
+++ b/pydicom/contrib/pydicom_series.py
@@ -57,7 +57,7 @@ except Exception:
 
 
 # Helper functions and classes
-class ProgressBar:
+class ProgressBar(object):
     """ To print progress to the screen.
     """
     def __init__(self, char='-', length=20):

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -174,7 +174,7 @@ def generate_uid(prefix=pydicom_root_UID, truncate=True):
 
     suffix = uuid.uuid1().int
 
-    dicom_uid = ''.join([prefix, str(suffix).lstrip("0")])
+    dicom_uid = ''.join([prefix, str(suffix)])
 
     if truncate:
         dicom_uid = dicom_uid[:max_uid_len]

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -5,10 +5,7 @@
 #    See the file license.txt included with this distribution, also
 #    available at https://github.com/darcymason/pydicom
 
-import os
 import uuid
-import datetime
-from math import fabs
 
 from pydicom._uid_dict import UID_dictionary
 from pydicom import compat
@@ -140,7 +137,8 @@ NotCompressedPixelTransferSyntaxes = [ExplicitVRLittleEndian,
                                       DeflatedExplicitVRLittleEndian,
                                       ExplicitVRBigEndian]
 
-# Many thanks to the Medical Connections for offering free valid UIDs (http://www.medicalconnections.co.uk/FreeUID.html)
+# Many thanks to the Medical Connections for offering free valid UIDs
+# (http://www.medicalconnections.co.uk/FreeUID.html)
 # Their service was used to obtain the following root UID for pydicom:
 pydicom_root_UID = '1.2.826.0.1.3680043.8.498.'
 pydicom_uids = {
@@ -148,7 +146,7 @@ pydicom_uids = {
 }
 
 
-def generate_uid(prefix=pydicom_root_UID, truncate=False):
+def generate_uid(prefix=pydicom_root_UID, truncate=True):
     '''
     Generate a dicom unique identifier based on host id, process id and current
     time. The max lenght of the generated UID is 64 caracters.
@@ -172,15 +170,11 @@ def generate_uid(prefix=pydicom_root_UID, truncate=False):
     max_uid_len = 64
 
     if prefix is None:
-        dicom_uid = '2.25.{0}'.format(uuid.uuid1().int)
-    else:
-        uid_info = [uuid.getnode(),
-                    fabs(os.getpid()),
-                    datetime.datetime.today().second,
-                    datetime.datetime.today().microsecond]  # nopep8
+        prefix = '2.25.'
 
-        suffix = ''.join([str(int(x)) for x in uid_info])
-        dicom_uid = ''.join([prefix, suffix])
+    suffix = uuid.uuid1().int
+
+    dicom_uid = ''.join([prefix, str(suffix).lstrip("0")])
 
     if truncate:
         dicom_uid = dicom_uid[:max_uid_len]

--- a/pydicom/uid.py
+++ b/pydicom/uid.py
@@ -5,6 +5,7 @@
 #    See the file license.txt included with this distribution, also
 #    available at https://github.com/darcymason/pydicom
 
+import os
 import uuid
 import datetime
 import random


### PR DESCRIPTION
The generation of uids was different if a prefix was passed or not.
It could have happened that when not passing a prefix that the same
uid was generated as the parameters used where not unique enought.

The change additonally takes care of two additional things stated in
Dicom PS3.5 2015a 9.1 UID Encoding Rules

no leading zeros
maximum 64 characters