### PR TITLE
add callback fxn to translate value-vr mismatches

### DIFF
--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -313,13 +313,13 @@ def DataElement_from_raw(raw_data_element, encoding=None):
     """Return a DataElement from a RawDataElement"""
     from pydicom.values import convert_value  # XXX buried here to avoid circular import filereader->Dataset->convert_value->filereader (for SQ parsing)
     raw = raw_data_element
-    VR = raw.VR
     
     # If user has hooked into conversion of raw values, call his/her routine
     import pydicom.config
     if pydicom.config.data_element_callback:
         raw = config.data_element_callback(raw_data_element,
                                           **config.data_element_callback_kwargs)
+    VR = raw.VR
     if VR is None:  # Can be if was implicit VR
         try:
             VR = dictionaryVR(raw.tag)

--- a/pydicom/util/fixer.py
+++ b/pydicom/util/fixer.py
@@ -80,7 +80,7 @@ def fix_mismatch_callback(raw_elem, **kwargs):
     return raw_elem
 
 
-def fix_mismatch(with_VRs=['DS', 'IS', 'PN']):
+def fix_mismatch(with_VRs=['PN', 'DS', 'IS']):
     """A callback function to check that RawDataElements are translatable
     with their provided VRs.  If not, re-attempt translation using
     some other translators.


### PR DESCRIPTION
Adds a callback function that checks if a raw data element is translatable with its VR. If it is not, translation is re-attempted with a configurable set of other VRs.  If a useable translator is found, then the raw data element is 'fixed' with the useable VR. 

I also changed `dataelem.DataElement_from_raw` to check the VR after the callback function.  This allows a change to data element's VR to get used for the actual translation.

Thoughts?