### PR TITLE
change __repr__ to use double quotes for numerics

### DIFF
--- a/pydicom/valuerep.py
+++ b/pydicom/valuerep.py
@@ -269,7 +269,7 @@ class DSfloat(float):
             return super(DSfloat, self).__str__()
 
     def __repr__(self):
-        return "'" + str(self) + "'"
+        return "\"" + str(self) + "\""
 
 
 class DSdecimal(Decimal):
@@ -334,7 +334,7 @@ class DSdecimal(Decimal):
             return super(DSdecimal, self).__str__()
 
     def __repr__(self):
-        return "'" + str(self) + "'"
+        return "\"" + str(self) + "\""
 
 # CHOOSE TYPE OF DS
 if config.use_DS_decimal:
@@ -393,7 +393,7 @@ class IS(int):
         if hasattr(self, 'original_string'):
             return "'" + self.original_string + "'"
         else:
-            return "'" + int.__str__(self) + "'"
+            return "\"" + int.__str__(self) + "\""
 
 
 def MultiString(val, valtype=str):


### PR DESCRIPTION
I believe the intention of using a single quoted string as a
representation is to prevent the introduction of floating point rounding
errors.

This change means that DSFloats (etc) can be correctly encoded with the
default python JSON library. Currently, the value is single-quoted in
the JSON, causing a parse error when trying to run json.loads().

Changing to double quotes should preserve the intended effect whilst
allowing JSON-based marshalling to work.


----

That's unless there's a reason single quotes are used. I've run the tests locally with success, with the exception of some (unrelated, I think) JPEG2000 tests.
