### PR TITLE
Add keyword and is_retired attributes to DataElement, docstring update, unit tests

### DIFF
--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -84,6 +84,12 @@ def dictionary_has_tag(tag):
 def dictionary_keyword(tag):
     """Return the official DICOM standard (since 2011) keyword for the tag"""
     return get_entry(tag)[4]
+    
+def dictionary_is_retired(tag):
+    """Return True if the dicom retired status is 'Retired' for the given tag"""
+    if 'retired' in get_entry(tag)[3].lower():
+        return True
+    return False
 
 # Set up a translation table for "cleaning" DICOM descriptions
 #    for backwards compatibility pydicom < 0.9.7 (before DICOM keywords)

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -78,7 +78,7 @@ class DataElement(object):
     ----------
     is_retired : bool
         For officially registered DICOM Data Elements this will be True if the 
-        retired status as given in PS3.6 Table 6-1 is 'RET'. For private of 
+        retired status as given in PS3.6 Table 6-1 is 'RET'. For private or 
         unknown Elements this will always be False
     keyword : str
         For officially registered DICOM Data Elements this will be the Keyword

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -14,7 +14,8 @@ from __future__ import absolute_import
 from pydicom import config  # don't import datetime_conversion directly
 from pydicom import compat
 from pydicom.config import logger
-from pydicom.datadict import dictionary_has_tag, dictionary_description
+from pydicom.datadict import dictionary_has_tag, dictionary_description, \
+    dictionary_keyword
 from pydicom.datadict import private_dictionary_description, dictionaryVR
 from pydicom.tag import Tag
 from pydicom.uid import UID
@@ -72,6 +73,25 @@ class DataElement(object):
     descripWidth -- maximum width of description field (default 35).
     maxBytesToDisplay -- longer data will display "array of # bytes" (default 16).
     showVR -- True (default) to include the dicom VR just before the value.
+    
+    Attributes
+    ----------
+    keyword : str
+        For officially registered DICOM Data Elements this will be the Keyword
+        as given in PS3.6 Table 6-1. For private or unknown Elements this will
+        return an empty string.
+    name : str
+        For officially registered DICOM Data Elements this will be the Name 
+        as given in PS3.6 Table 6-1. For private Elements known to pydicom this 
+        will be the Name in the format '[name]'. For unknown private Elements
+        this will be 'Private Creator'. For unknown Elements this will return
+        an empty string.
+    tag : pydicom.tag.Tag
+        The DICOM Tag for the Data Element
+    value
+        The Data Element's stored value(s)
+    VM : int
+        The Value Multiplicity of the Data Element's stored value(s)
     """
     descripWidth = 35
     maxBytesToDisplay = 16
@@ -249,7 +269,14 @@ class DataElement(object):
         else:
             name = ""
         return name
-
+        
+    @property
+    def keyword(self):
+        if dictionary_has_tag(self.tag):
+            return dictionary_keyword(self.tag)
+        else:
+            return ''
+    
     def __repr__(self):
         """Handle repr(data_element)"""
         if self.VR == "SQ":

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -15,7 +15,7 @@ from pydicom import config  # don't import datetime_conversion directly
 from pydicom import compat
 from pydicom.config import logger
 from pydicom.datadict import dictionary_has_tag, dictionary_description, \
-    dictionary_keyword
+    dictionary_keyword, dictionary_is_retired
 from pydicom.datadict import private_dictionary_description, dictionaryVR
 from pydicom.tag import Tag
 from pydicom.uid import UID
@@ -76,6 +76,10 @@ class DataElement(object):
     
     Attributes
     ----------
+    is_retired : bool
+        For officially registered DICOM Data Elements this will be True if the 
+        retired status as given in PS3.6 Table 6-1 is 'RET'. For private of 
+        unknown Elements this will always be False
     keyword : str
         For officially registered DICOM Data Elements this will be the Keyword
         as given in PS3.6 Table 6-1. For private or unknown Elements this will
@@ -269,7 +273,15 @@ class DataElement(object):
         else:
             name = ""
         return name
-        
+    
+    @property
+    def is_retired(self):
+        """The data_element's retired status"""
+        if dictionary_has_tag(self.tag):
+            return dictionary_is_retired(tag)
+        else:
+            return False
+    
     @property
     def keyword(self):
         """The data_element's keyword (if known)"""

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -278,7 +278,7 @@ class DataElement(object):
     def is_retired(self):
         """The data_element's retired status"""
         if dictionary_has_tag(self.tag):
-            return dictionary_is_retired(tag)
+            return dictionary_is_retired(self.tag)
         else:
             return False
     

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -272,6 +272,7 @@ class DataElement(object):
         
     @property
     def keyword(self):
+        """The data_element's keyword (if known)"""
         if dictionary_has_tag(self.tag):
             return dictionary_keyword(self.tag)
         else:

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -171,7 +171,7 @@ class Dataset(dict):
         """
         # First check if a valid DICOM keyword and if we have that data element
         tag = tag_for_name(name)
-        if tag and tag in self:
+        if tag is not None and tag in self:
             dict.__delitem__(self, tag)  # direct to dict as we know we have key
         # If not a DICOM name in this dataset, check for regular instance name
         #   can't do delete directly, that will call __delattr__ again

--- a/tests/test_dataelem.py
+++ b/tests/test_dataelem.py
@@ -22,6 +22,9 @@ class DataElementTests(unittest.TestCase):
         self.data_elementDS = DataElement((1, 2), "DS", "42.00001")
         self.data_elementMulti = DataElement((1, 2), "DS",
                                              ['42.1', '42.2', '42.3'])
+        self.data_elementCommand = DataElement(0x00000000, 'UL', 100)
+        self.data_elementPrivate = DataElement(0x00090000, 'UL', 101)
+        self.data_elementRetired = DataElement(0x00080010, 'SH', 102)
 
     def testVM1(self):
         """DataElement: return correct value multiplicity for VM > 1........"""
@@ -49,6 +52,17 @@ class DataElementTests(unittest.TestCase):
         ds.TransferSyntaxUID += ".4.5.6"
         self.assertTrue(isinstance(ds.TransferSyntaxUID, UID),
                         "+= to UID did not keep as UID class")
+                        
+    def testKeyword(self):
+        """DataElement: return correct keyword"""
+        self.assertEqual(self.data_elementCommand.keyword, 'CommandGroupLength')
+        self.assertEqual(self.data_elementPrivate.keyword, '')
+    
+    def testRetired(self):
+        """DataElement: return correct is_retired"""
+        self.assertEqual(self.data_elementCommand.is_retired, False)
+        self.assertEqual(self.data_elementRetired.is_retired, True)
+        self.assertEqual(self.data_elementPrivate.is_retired, False)
 
 
 class RawDataElementTests(unittest.TestCase):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -270,7 +270,17 @@ class DatasetTests(unittest.TestCase):
         ds = self.dummy_dataset()
         del ds.TreatmentMachineName
         self.assertRaises(AttributeError, testAttribute)
-
+        
+    def testDeleteDicomCommandGroupLength(self):
+        """Dataset: delete CommandGroupLength doesn't raise AttributeError.."""
+        def testAttribute():
+            ds.CommandGroupLength
+        
+        ds = self.dummy_dataset()
+        ds.CommandGroupLength = 100 # (0x0000, 0x0000)
+        del ds.CommandGroupLength
+        self.assertRaises(AttributeError, testAttribute)
+    
     def testDeleteOtherAttr(self):
         """Dataset: delete non-DICOM attribute by name......................"""
         ds = self.dummy_dataset()


### PR DESCRIPTION
- Brings DataElement attributes into line with the information available in PS3.6 Table 6-1.
- Adds unit test for #253, unit tests for DataElement's new keyword and is_retired attributes
- Adds information about DataElement's attributes to its docstring
