### PR TITLE
Fix infinite loop in MultiValue.extend when extending with self

### DIFF
--- a/pydicom/multival.py
+++ b/pydicom/multival.py
@@ -48,7 +48,7 @@ class MultiValue(list):
         return MultiValue(self.type_constructor, self)
         
     def extend(self, list_of_vals):
-        super(MultiValue, self).extend((self.type_constructor(x) for x in list_of_vals))
+        super(MultiValue, self).extend([self.type_constructor(x) for x in list_of_vals])
 
     def insert(self, position, val):
         super(MultiValue, self).insert(position, self.type_constructor(val))

--- a/tests/test_multival.py
+++ b/tests/test_multival.py
@@ -55,6 +55,12 @@ class MultiValuetests(unittest.TestCase):
         self.assertTrue(isinstance(multival[-1], IS))
         self.assertEqual(multival[-2], 7, "Item set by extend not correct value")
 
+    def testExtendSelf(self):
+        """MultiValue: Extending a MultiValue with itself does not cause infinite loop and result is correct."""
+        multival = MultiValue(IS, [1, 2, 3])
+        multival.extend(multival)
+        self.assertEqual(multival, MultiValue(IS, [1, 2, 3, 1, 2, 3]), "Item set by extend self not correct value")
+
     def testSlice(self):
         """MultiValue: Setting slice converts items to required type."""
         multival = MultiValue(IS, range(7))


### PR DESCRIPTION
Replacing generator expression with listcomp will ensure we are not iterating over a potentially mutating list. This issue arose after upgrading pydicom from version 0.9.6 -> 0.9.9 caused a regression in one of our unit tests.