### PR TITLE
Test case and fixes for 3d color jpeg issue

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -548,13 +548,17 @@ class Dataset(dict):
         # Note the following reshape operations return a new *view* onto arr, but don't copy the data
         if 'NumberOfFrames' in self and self.NumberOfFrames > 1:
             if self.SamplesPerPixel > 1:
-                arr = arr.reshape(self.SamplesPerPixel, self.NumberOfFrames, self.Rows, self.Columns)
+                arr = arr.reshape(self.NumberOfFrames, self.Rows, self.Columns,  self.SamplesPerPixel)
             else:
                 arr = arr.reshape(self.NumberOfFrames, self.Rows, self.Columns)
         else:
             if self.SamplesPerPixel > 1:
                 if self.BitsAllocated == 8:
-                    arr = arr.reshape(self.SamplesPerPixel, self.Rows, self.Columns)
+                    if self.PlanarConfiguration == 0:
+                        arr = arr.reshape(self.Rows, self.Columns, self.SamplesPerPixel)
+                    else:
+                        arr = arr.reshape(self.SamplesPerPixel, self.Rows, self.Columns)
+                        arr = arr.transpose(1, 2, 0)
                 else:
                     raise NotImplementedError("This code only handles SamplesPerPixel > 1 if Bits Allocated = 8")
             else:


### PR DESCRIPTION
This is a test case and a fix for the issue raised in pull request #257  

The actual test file is uncomfortably large, but I could not get either gdcm or dcmtk to properly downsize it.  When I used gdcm to decompress it, it also seemed to corrupt the last two channels (eg, a pixel showing values (57, 57, 57) in Osirix viewer on the original, would show (57, 128, 128) after being decompressed with gdcm.)  The test case asserts that the pixel data shape is as expected and that two example pixels are correctly decoded.

 