### PR TITLE
Fix a bug that occurred when GDCM returned a buffer that was longer than the data

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -485,7 +485,7 @@ class Dataset(dict):
 
             # We make sure that all the bytes after are in fact zeros
             padding = pixel_bytearray[n_bytes:]
-            if numpy.sum(numpy.fromstring(padding, numpy.byte)) == 0:
+            if numpy.any(numpy.fromstring(padding, numpy.byte)):
                 pixel_bytearray = pixel_bytearray[:n_bytes]
             else:
                 # We revert to the old behavior which should then result in a

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -485,7 +485,7 @@ class Dataset(dict):
 
             # We make sure that all the bytes after are in fact zeros
             padding = pixel_bytearray[n_bytes:]
-            if sum(padding) == 0:
+            if all(x == b'\x00' for x in padding):
                 pixel_bytearray = pixel_bytearray[:n_bytes]
             else:
                 # We revert to the old behavior which should then result in a

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -475,6 +475,13 @@ class Dataset(dict):
             if gdcm_image.GetNeedByteSwap():
                 numpy_dtype.newbyteorder('S')
 
+        # Here we need to be careful because in some cases, GDCM reads a
+        # buffer that is too large, so we need to make sure we only include
+        # the first n_rows * n_columns * dtype_size bytes.
+        n_bytes = self.Rows * self.Columns * numpy.dtype(numpy_dtype).itemsize
+        if len(pixel_bytearray) > n_bytes:
+            pixel_bytearray = pixel_bytearray[:n_bytes]
+
         pixel_array = numpy.fromstring(pixel_bytearray, dtype=numpy_dtype)
 
         # Note the following reshape operations return a new *view* onto pixel_array, but don't copy the data

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -485,7 +485,7 @@ class Dataset(dict):
 
             # We make sure that all the bytes after are in fact zeros
             padding = pixel_bytearray[n_bytes:]
-            if padding.count(b'\x00') == len(padding):
+            if sum(padding) == 0:
                 pixel_bytearray = pixel_bytearray[:n_bytes]
             else:
                 # We revert to the old behavior which should then result in a

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -478,9 +478,19 @@ class Dataset(dict):
         # Here we need to be careful because in some cases, GDCM reads a
         # buffer that is too large, so we need to make sure we only include
         # the first n_rows * n_columns * dtype_size bytes.
+
         n_bytes = self.Rows * self.Columns * numpy.dtype(numpy_dtype).itemsize
+
         if len(pixel_bytearray) > n_bytes:
-            pixel_bytearray = pixel_bytearray[:n_bytes]
+
+            # We make sure that all the bytes after are in fact zeros
+            padding = pixel_bytearray[n_bytes:]
+            if padding.count(b'\x00') == len(padding):
+                pixel_bytearray = pixel_bytearray[:n_bytes]
+            else:
+                # We revert to the old behavior which should then result in a
+                # Numpy error later on.
+                pass
 
         pixel_array = numpy.fromstring(pixel_bytearray, dtype=numpy_dtype)
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -485,7 +485,7 @@ class Dataset(dict):
 
             # We make sure that all the bytes after are in fact zeros
             padding = pixel_bytearray[n_bytes:]
-            if all(x == b'\x00' for x in padding):
+            if numpy.sum(numpy.fromstring(padding, numpy.byte)) == 0:
                 pixel_bytearray = pixel_bytearray[:n_bytes]
             else:
                 # We revert to the old behavior which should then result in a


### PR DESCRIPTION
This is a fix for https://github.com/darcymason/pydicom/issues/270 - basically GDCM was returning a large byte array that had a lot of padding with zeros at the end.