### PR TITLE
Added support for elements with a VR of OD and OL

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -176,7 +176,6 @@ def write_OWvalue(fp, data_element):
     """Write a data_element with VR of 'other word' (OW).
 
     Note: This **does not currently do the byte swapping** for Endian state.
-
     """
     # XXX for now just write the raw bytes without endian swapping
     fp.write(data_element.value)
@@ -601,6 +600,8 @@ writers = {'UL': (write_numbers, 'L'),
            'FD': (write_numbers, 'd'),
            'OF': (write_numbers, 'f'),
            'OB': (write_OBvalue, None),
+           'OD': (write_OWvalue, None),
+           'OL': (write_OWvalue, None),
            'UI': (write_UI, None),
            'SH': (write_string, None),
            'DA': (write_DA, None),

--- a/pydicom/values.py
+++ b/pydicom/values.py
@@ -121,7 +121,31 @@ def convert_IS_string(byte_string, is_little_endian, struct_format=None):
 
 
 def convert_numbers(byte_string, is_little_endian, struct_format):
-    """Read a "value" of type struct_format from the dicom file. "Value" can be more than one number"""
+    """Convert `byte_string` to a value, depending on `struct_format`.
+
+    Given an encoded DICOM Element value, use `struct_format` and the endianness
+    of the data to decode it.
+
+    Parameters
+    ----------
+    byte_string : bytes
+        The raw byte data to decode.
+    is_little_endian : bool
+        The encoding of `byte_string`.
+    struct_format : str
+        The type of data encoded in `byte_string`.
+
+    Returns
+    -------
+    str
+        If there is no encoded data in `byte_string` then an empty string will
+        be returned.
+    value
+        If `byte_string` encodes a single value then it will be returned.
+    list
+        If `byte_string` encodes multiple values then a list of the decoded
+        values will be returned.
+    """
     endianChar = '><'[is_little_endian]
     bytes_per_value = calcsize("=" + struct_format)  # "=" means use 'standard' size, needed on 64-bit systems.
     length = len(byte_string)
@@ -323,6 +347,8 @@ converters = {
     'FD': (convert_numbers, 'd'),
     'OF': (convert_numbers, 'f'),
     'OB': convert_OBvalue,
+    'OD': convert_OBvalue,
+    'OL': convert_OBvalue,
     'UI': convert_UI,
     'SH': convert_string,
     'DA': convert_DA_string,

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -381,8 +381,10 @@ class ReaderTests(unittest.TestCase):
 class ReadDataElementTests(unittest.TestCase):
     def setUp(self):
         ds = Dataset()
-        #ds.DoubleFloatPixelData = FIXME # VR of OD
-        # No element in _dicom_dict.py has a VR of OL
+        ds.DoubleFloatPixelData = b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                                  b'\x01\x01\x02\x03\x04\x05\x06\x07' # VR of OD
+        ds.SelectorOLValue = b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                             b'\x01\x01\x02\x03' # VR of OL
         ds.PotentialReasonsForProcedure = ['A', 'B', 'C'] # VR of UC, odd length
         ds.StrainDescription = 'Test' # Even length
         ds.URNCodeValue = 'http://test.com' # VR of UR
@@ -400,6 +402,38 @@ class ReadDataElementTests(unittest.TestCase):
         file_ds.is_implicit_VR = False
         file_ds.is_little_endian = True
         file_ds.save_as(self.fp_ex)
+        
+    def test_read_OD_implicit_little(self):
+        """Check creation of OD DataElement from byte data works correctly."""
+        ds = read_file(self.fp, force=True)
+        ref_elem = ds.get(0x7fe00009)
+        elem = DataElement(0x7fe00009, 'OD', b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                                             b'\x01\x01\x02\x03\x04\x05\x06\x07')
+        self.assertEqual(ref_elem, elem)
+
+    def test_read_OD_explicit_little(self):
+        """Check creation of OD DataElement from byte data works correctly."""
+        ds = read_file(self.fp_ex, force=True)
+        ref_elem = ds.get(0x7fe00009)
+        elem = DataElement(0x7fe00009, 'OD', b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                                             b'\x01\x01\x02\x03\x04\x05\x06\x07')
+        self.assertEqual(ref_elem, elem)
+
+    def test_read_OL_implicit_little(self):
+        """Check creation of OL DataElement from byte data works correctly."""
+        ds = read_file(self.fp, force=True)
+        ref_elem = ds.get(0x00720075)
+        elem = DataElement(0x00720075, 'OL', b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                                             b'\x01\x01\x02\x03')
+        self.assertEqual(ref_elem, elem)
+
+    def test_read_OL_explicit_little(self):
+        """Check creation of OL DataElement from byte data works correctly."""
+        ds = read_file(self.fp_ex, force=True)
+        ref_elem = ds.get(0x00720075)
+        elem = DataElement(0x00720075, 'OL', b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                                             b'\x01\x01\x02\x03')
+        self.assertEqual(ref_elem, elem)
 
     def test_read_UC_implicit_little(self):
         """Check creation of DataElement from byte data works correctly."""

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -248,6 +248,94 @@ class WriteDataElementTests(unittest.TestCase):
         msg = "'%r' '%r'" % (expected, got)
         self.assertEqual(expected, got, msg)
 
+    def test_write_OD_implicit_little(self):
+        """Test writing elements with VR of OD works correctly."""
+        # VolumetricCurvePoints
+        bytestring = b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                     b'\x01\x01\x02\x03\x04\x05\x06\x07'
+        elem = DataElement(0x0070150d, 'OD', bytestring)
+        encoded_elem = self.encode_element(elem)
+        # Tag pair (0070, 150d): 70 00 0d 15
+        # Length (16): 10 00 00 00
+        #             | Tag          |   Length      |    Value ->
+        ref_bytes = b'\x70\x00\x0d\x15\x10\x00\x00\x00' + bytestring
+        self.assertEqual(encoded_elem, ref_bytes)
+
+        # Empty data
+        elem.value = b''
+        encoded_elem = self.encode_element(elem)
+        ref_bytes = b'\x70\x00\x0d\x15\x00\x00\x00\x00'
+        self.assertEqual(encoded_elem, ref_bytes)
+
+    def test_write_OD_explicit_little(self):
+        """Test writing elements with VR of OD works correctly.
+
+        Elements with a VR of 'OD' use the newer explicit VR
+        encoding (see PS3.5 Section 7.1.2).
+        """
+        # VolumetricCurvePoints
+        bytestring = b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                     b'\x01\x01\x02\x03\x04\x05\x06\x07'
+        elem = DataElement(0x0070150d, 'OD', bytestring)
+        encoded_elem = self.encode_element(elem, False, True)
+        # Tag pair (0070, 150d): 70 00 0d 15
+        # VR (OD): \x4f\x44
+        # Reserved: \x00\x00
+        # Length (16): \x10\x00\x00\x00
+        #             | Tag          | VR    | Rsrvd |   Length      |    Value ->
+        ref_bytes = b'\x70\x00\x0d\x15\x4f\x44\x00\x00\x10\x00\x00\x00' + bytestring
+        self.assertEqual(encoded_elem, ref_bytes)
+
+        # Empty data
+        elem.value = b''
+        encoded_elem = self.encode_element(elem, False, True)
+        ref_bytes = b'\x70\x00\x0d\x15\x4f\x44\x00\x00\x00\x00\x00\x00'
+        self.assertEqual(encoded_elem, ref_bytes)
+        
+    def test_write_OL_implicit_little(self):
+        """Test writing elements with VR of OL works correctly."""
+        # TrackPointIndexList
+        bytestring = b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                     b'\x01\x01\x02\x03'
+        elem = DataElement(0x00660129, 'OL', bytestring)
+        encoded_elem = self.encode_element(elem)
+        # Tag pair (0066, 0129): 66 00 29 01
+        # Length (12): 0c 00 00 00
+        #             | Tag          |   Length      |    Value ->
+        ref_bytes = b'\x66\x00\x29\x01\x0c\x00\x00\x00' + bytestring
+        self.assertEqual(encoded_elem, ref_bytes)
+
+        # Empty data
+        elem.value = b''
+        encoded_elem = self.encode_element(elem)
+        ref_bytes = b'\x66\x00\x29\x01\x00\x00\x00\x00'
+        self.assertEqual(encoded_elem, ref_bytes)
+
+    def test_write_OL_explicit_little(self):
+        """Test writing elements with VR of OL works correctly.
+
+        Elements with a VR of 'OL' use the newer explicit VR
+        encoding (see PS3.5 Section 7.1.2).
+        """
+        # TrackPointIndexList
+        bytestring = b'\x00\x01\x02\x03\x04\x05\x06\x07' \
+                     b'\x01\x01\x02\x03'
+        elem = DataElement(0x00660129, 'OL', bytestring)
+        encoded_elem = self.encode_element(elem, False, True)
+        # Tag pair (0066, 0129): 66 00 29 01
+        # VR (OL): \x4f\x4c
+        # Reserved: \x00\x00
+        # Length (12): 0c 00 00 00
+        #             | Tag          | VR    | Rsrvd |   Length      |    Value ->
+        ref_bytes = b'\x66\x00\x29\x01\x4f\x4c\x00\x00\x0c\x00\x00\x00' + bytestring
+        self.assertEqual(encoded_elem, ref_bytes)
+
+        # Empty data
+        elem.value = b''
+        encoded_elem = self.encode_element(elem, False, True)
+        ref_bytes = b'\x66\x00\x29\x01\x4f\x4c\x00\x00\x00\x00\x00\x00'
+        self.assertEqual(encoded_elem, ref_bytes)
+
     def test_write_UC_implicit_little(self):
         """Test writing elements with VR of UC works correctly."""
         # VM 1, even data


### PR DESCRIPTION
I noticed that pydicom does no endianness conversion when reading/writing OW byte data so I didn't include any for these two (plus big endian was retired last year). If I'm wrong about that, let me know.

Related to #304, #295 and #216.