### PR TITLE
Add ambiguous VR correction to dataset reading

### DIFF
--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -359,7 +359,11 @@ def read_dataset(fp, is_implicit_VR, is_little_endian, bytelength=None,
     except NotImplementedError as details:
         logger.error(details)
 
-    return Dataset(raw_data_elements)
+    # Attempt to correct elements with ambiguous VR
+    from pydicom.filewriter import correct_ambiguous_vr # avoid circular import
+    ds = correct_ambiguous_vr(Dataset(raw_data_elements), is_little_endian)
+
+    return ds
 
 
 def read_sequence(fp, is_implicit_VR, is_little_endian, bytelength, encoding,

--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -359,9 +359,19 @@ def read_dataset(fp, is_implicit_VR, is_little_endian, bytelength=None,
     except NotImplementedError as details:
         logger.error(details)
 
-    # Attempt to correct elements with ambiguous VR
-    from pydicom.filewriter import correct_ambiguous_vr # avoid circular import
-    ds = correct_ambiguous_vr(Dataset(raw_data_elements), is_little_endian)
+    ds = Dataset(raw_data_elements)
+
+    # Attempt to correct elements with ambiguous VR - can only do this with a 
+    #   fully read dataset
+    if defer_size is None:
+        from pydicom.filewriter import correct_ambiguous_vr # avoid circular
+        # Correcting ambiguous VR requires iterating through the raw dataset
+        #   elements, so any bad elements will appear for the first time.
+        #   If that happens then stop trying to correct.
+        try:
+            ds = correct_ambiguous_vr(ds, is_little_endian)
+        except ValueError:
+            pass
 
     return ds
 

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -377,6 +377,24 @@ class ReaderTests(unittest.TestCase):
             pl_data = pl_data_ds.pixel_array
             self.assertTrue(numpy.all(px_data == pl_data))
 
+    def test_correct_ambiguous_vr(self):
+        """Test correcting ambiguous VR elements on read"""
+        ds = Dataset()
+        ds.PixelRepresentation = 0
+        ds.add(DataElement(0x00280108, 'US', 10))
+        ds.add(DataElement(0x00280109, 'US', 500))
+        
+
+        fp = BytesIO()
+        file_ds = FileDataset(fp, ds)
+        file_ds.is_implicit_VR = True
+        file_ds.is_little_endian = True
+        file_ds.save_as(fp)
+        
+        ds = read_file(fp, force=True)
+        self.assertEqual(ds[0x00280108].VR, 'US')
+        self.assertEqual(ds.SmallestPixelValueInSeries, 10)
+
 
 class ReadDataElementTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -383,14 +383,13 @@ class ReaderTests(unittest.TestCase):
         ds.PixelRepresentation = 0
         ds.add(DataElement(0x00280108, 'US', 10))
         ds.add(DataElement(0x00280109, 'US', 500))
-        
 
         fp = BytesIO()
         file_ds = FileDataset(fp, ds)
         file_ds.is_implicit_VR = True
         file_ds.is_little_endian = True
         file_ds.save_as(fp)
-        
+
         ds = read_file(fp, force=True)
         self.assertEqual(ds[0x00280108].VR, 'US')
         self.assertEqual(ds.SmallestPixelValueInSeries, 10)


### PR DESCRIPTION
Related to #298 

Addresses #201, #90, #42 

It didn't turn out as elegant as I'd hoped, it might be a bit too early in the reading process but I wanted it to apply to reading any dataset not only file reads. Comments?

Some of those old issues appear to have already been addressed (#149 for example).