### PR TITLE
make DicomBytesIO a class rather than a function

### DIFF
--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -161,5 +161,6 @@ def DicomFile(*args, **kwargs):
     return DicomFileLike(open(*args, **kwargs))
 
 
-def DicomBytesIO(*args, **kwargs):
-    return DicomFileLike(BytesIO(*args, **kwargs))
+class DicomBytesIO(DicomFileLike):
+    def __init__(self, *args, **kwargs):
+        super(DicomBytesIO, self).__init__(BytesIO(*args, **kwargs))

--- a/pydicom/filebase.py
+++ b/pydicom/filebase.py
@@ -164,3 +164,6 @@ def DicomFile(*args, **kwargs):
 class DicomBytesIO(DicomFileLike):
     def __init__(self, *args, **kwargs):
         super(DicomBytesIO, self).__init__(BytesIO(*args, **kwargs))
+
+    def getvalue(self):
+        return self.parent.getvalue()

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -181,7 +181,10 @@ class ReaderTests(unittest.TestCase):
         self.assertEqual(ct.Rows, 128, "Rows not 128")
         self.assertEqual(ct.Columns, 128, "Columns not 128")
         self.assertEqual(ct.BitsStored, 16, "Bits Stored not 16")
-        self.assertEqual(len(ct.PixelData), 128 * 128 * 2, "Pixel data not expected length")
+        # in pydicom v >= 1.0, pixel data auto-converted to numpy.
+        #    Avoid autoconversion using get_item
+        got = len(ct.get_item(0x7fe00010).value)
+        self.assertEqual(got, 128 * 128 * 2, "Pixel data not expected length")
 
         # Also test private elements name can be resolved:
         expected = "[Duration of X-ray on]"
@@ -432,7 +435,7 @@ class ReadDataElementTests(unittest.TestCase):
         file_ds.is_implicit_VR = False
         file_ds.is_little_endian = True
         file_ds.save_as(self.fp_ex)
-        
+
     def test_read_OD_implicit_little(self):
         """Check creation of OD DataElement from byte data works correctly."""
         ds = read_file(self.fp, force=True)

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -181,10 +181,7 @@ class ReaderTests(unittest.TestCase):
         self.assertEqual(ct.Rows, 128, "Rows not 128")
         self.assertEqual(ct.Columns, 128, "Columns not 128")
         self.assertEqual(ct.BitsStored, 16, "Bits Stored not 16")
-        # in pydicom v >= 1.0, pixel data auto-converted to numpy.
-        #    Avoid autoconversion using get_item
-        got = len(ct.get_item(0x7fe00010).value)
-        self.assertEqual(got, 128 * 128 * 2, "Pixel data not expected length")
+        self.assertEqual(len(ct.PixelData), 128 * 128 * 2, "Pixel data not expected length")
 
         # Also test private elements name can be resolved:
         expected = "[Duration of X-ray on]"

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -228,7 +228,7 @@ class WriteDataElementTests(unittest.TestCase):
         fp.is_implicit_VR = is_implicit_VR
         fp.is_little_endian = is_little_endian
         write_data_element(fp, elem)
-        byte_string = fp.parent.getvalue()
+        byte_string = fp.getvalue()
         fp.close()
         return byte_string
 
@@ -241,7 +241,7 @@ class WriteDataElementTests(unittest.TestCase):
             " 00 00 00 00"   # length 0
         ))
         write_data_element(self.f1, data_elem)
-        got = self.f1.parent.getvalue()
+        got = self.f1.getvalue()
         msg = ("Did not write zero-length AT value correctly. "
                "Expected %r, got %r") % (bytes2hex(expected), bytes2hex(got))
         msg = "%r %r" % (type(expected), type(got))
@@ -291,7 +291,7 @@ class WriteDataElementTests(unittest.TestCase):
         encoded_elem = self.encode_element(elem, False, True)
         ref_bytes = b'\x70\x00\x0d\x15\x4f\x44\x00\x00\x00\x00\x00\x00'
         self.assertEqual(encoded_elem, ref_bytes)
-        
+
     def test_write_OL_implicit_little(self):
         """Test writing elements with VR of OL works correctly."""
         # TrackPointIndexList


### PR DESCRIPTION
Closes: https://github.com/darcymason/pydicom/issues/313
Partially addresses: https://github.com/darcymason/pydicom/issues/310