### PR TITLE
Changes to Tag and BaseTag, unit tests for tag module, minor docstring update for Dataset

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -213,10 +213,10 @@ class Dataset(dict):
             5, Section 6.2).
         value
             The value of the data element. One of the following:
-            * a single string value
-            * a number
+            * a single string or number
             * a list or tuple with all strings or all numbers
             * a multi-value string with backslash separator
+            * for a sequence DataElement, an empty list or list of Dataset
         """
         data_element = DataElement(tag, VR, value)
         # use data_element.tag since DataElement verified it
@@ -234,7 +234,7 @@ class Dataset(dict):
         -------
         pydicom.dataelem.DataElement or None
             For the given DICOM element `keyword`, return the corresponding
-            Dataset Dataelement if present, None otherwise.
+            Dataset DataElement if present, None otherwise.
         """
         tag = tag_for_name(name)
         if tag:
@@ -459,7 +459,7 @@ class Dataset(dict):
     def __getattr__(self, name):
         """Intercept requests for unknown Dataset attribute names.
 
-        If the name matches a Dicom keyword, return the value for the
+        If the name matches a DICOM keyword, return the value for the
         DataElement with the corresponding tag.
 
         Parameters
@@ -587,14 +587,14 @@ class Dataset(dict):
         return ds
 
     def __iter__(self):
-        """Iterate through the Dataset, yielding DataElements.
+        """Iterate through the top-level of the Dataset, yielding DataElements.
 
         >>> for elem in ds:
         >>>     print(elem)
 
-        The data_elements are returned in DICOM order, i.e. in increasing order
-        by tag value. Sequence items are returned as a single DataElement, so it
-        is up to the calling code to recurse into the Sequence items if desired.
+        The DataElements are returned in increasing tag value order.
+        Sequence items are returned as a single DataElement, so it is up to the
+        calling code to recurse into the Sequence items if desired.
 
         Yields
         ------
@@ -1137,8 +1137,8 @@ class Dataset(dict):
     def __setattr__(self, name, value):
         """Intercept any attempts to set a value for an instance attribute.
 
-        If name is a dicom descriptive string (cleaned with CleanName), then
-        set the corresponding tag and data_element.
+        If name is a DICOM descriptive string (cleaned with CleanName), then
+        set the corresponding tag and DataElement.
         Else, set an instance (python) attribute as any other class would do.
 
         Parameters
@@ -1226,7 +1226,7 @@ class Dataset(dict):
                 self[Tag(key)] = value
 
     def iterall(self):
-        """Iterate through the dataset, yielding all data elements.
+        """Iterate through the Dataset, yielding all DataElements.
 
         Unlike Dataset.__iter__, this *does* recurse into sequences,
         and so returns all data elements as if the file were "flattened".
@@ -1246,13 +1246,12 @@ class Dataset(dict):
     def walk(self, callback, recursive=True):
         """Iterate through the DataElements and run `callback` on each.
 
-        Visit all data_elements, possibly recursing into sequences and their datasets,
-        The callback function is called for each data_element
-        (including SQ element).
-        Can be used to perform an operation on certain types of data_elements.
-        E.g., `remove_private_tags`() finds all private tags and deletes them.
-        `DataElement`s will come back in DICOM order (by increasing tag number
-        within their dataset)
+        Visit all DataElements, possibly recursing into sequences and their
+        datasets. The callback function is called for each DataElement
+        (including SQ element). Can be used to perform an operation on certain
+        types of DataElements. E.g., `remove_private_tags`() finds all private
+        tags and deletes them. DataElement`s will come back in DICOM order (by
+        increasing tag number within their dataset).
 
         Parameters
         ----------

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -51,7 +51,7 @@ def Tag(arg, arg2=None):
         # Check argument types aren't mixed (i.e. str and int)
         arg_types = set([type(arg[0]), type(arg[1])])
         if len(arg_types) != 1:
-            raise ValueError("Both arguments must be the same type.")
+            raise ValueError("Both arguments for Tag must be the same type.")
 
         # Double str parameters
         if isinstance(arg[0], (str, compat.text_type)):

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -109,7 +109,7 @@ class BaseTag(BaseTag_base_class):
     #   See Ordering Comparisons at:
     #   http://docs.python.org/dev/3.0/whatsnew/3.0.html
     def __le__(self, other):
-        """Less than or equal to comparison for `self` and `other`."""
+        """Return True if `self`  is less than or equal to `other`."""
         return (self == other or self < other)
 
     def __lt__(self, other):
@@ -123,11 +123,11 @@ class BaseTag(BaseTag_base_class):
         return BaseTag_base_class(self) < BaseTag_base_class(other)
 
     def __ge__(self, other):
-        """Greater than or equal to comparison for `self` and `other`."""
+        """Return True if `self` is greater than or equal to `other`."""
         return (self == other or self > other)
 
     def __gt__(self, other):
-        """Greater than comparison for `self` and `other`."""
+        """Return True if `self` is greater than `other`."""
         return not (self == other or self < other)
 
     def __eq__(self, other):

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -50,9 +50,14 @@ else:
 class BaseTag(BaseTag_base_class):
     """Class for storing the dicom (group, element) tag"""
     # Override comparisons so can convert "other" to Tag as necessary
-    #   See Ordering Comparisons at http://docs.python.org/dev/3.0/whatsnew/3.0.html
+    #   See Ordering Comparisons at:
+    #   http://docs.python.org/dev/3.0/whatsnew/3.0.html
+    def __le__(self, other):
+        """Less than or equal to comparison for `self` and `other`."""
+        return (self == other or self < other)
 
     def __lt__(self, other):
+        """Less than comparison for `self` and `other`."""
         # Check if comparing with another Tag object; if not, create a temp one
         if not isinstance(other, BaseTag):
             try:
@@ -61,7 +66,16 @@ class BaseTag(BaseTag_base_class):
                 raise TypeError("Cannot compare Tag with non-Tag item")
         return BaseTag_base_class(self) < BaseTag_base_class(other)
 
+    def __ge__(self, other):
+        """Greater than or equal to comparison for `self` and `other`."""
+        return (self == other or self > other)
+
+    def __gt__(self, other):
+        """Greater than comparison for `self` and `other`."""
+        return not (self == other or self < other)
+
     def __eq__(self, other):
+        """Equality comparison for `self` and `other`."""
         # Check if comparing with another Tag object; if not, create a temp one
         if not isinstance(other, BaseTag):
             try:
@@ -71,13 +85,8 @@ class BaseTag(BaseTag_base_class):
         return BaseTag_base_class(self) == BaseTag_base_class(other)
 
     def __ne__(self, other):
-        # Check if comparing with another Tag object; if not, create a temp one
-        if not isinstance(other, BaseTag):
-            try:
-                other = Tag(other)
-            except:
-                raise TypeError("Cannot compare Tag with non-Tag item")
-        return BaseTag_base_class(self) != BaseTag_base_class(other)
+        """Inequality comparison for `self` and `other`."""
+        return not (self == other)
 
     # For python 3, any override of __cmp__ or __eq__ immutable requires
     #   explicit redirect of hash function to the parent class

--- a/pydicom/tag.py
+++ b/pydicom/tag.py
@@ -22,6 +22,7 @@ def Tag(arg, arg2=None):
     * Tag(0x00100015)
     * Tag('0x00100015')
     * Tag((0x10, 0x50))
+    * Tag(('0x10', '0x50'))
     * Tag(0x0010, 0x0015)
     * Tag(0x10, 0x15)
     * Tag(2341, 0x10)
@@ -32,7 +33,7 @@ def Tag(arg, arg2=None):
     arg : int or str or 2-tuple/list
         If int or str, then either the group or the combined group/element
         number of the DICOM tag. If 2-tuple/list then the (group, element)
-        numbers.
+        numbers as int or str.
     arg2 : int or str, optional
         The element number of the DICOM tag, required when `arg` only contains
         the group number of the tag.

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -5,7 +5,219 @@
 #    available at https://github.com/darcymason/pydicom
 
 import unittest
-from pydicom.tag import Tag, TupleTag
+from pydicom.tag import BaseTag, Tag, TupleTag
+
+
+class TestBaseTag(unittest.TestCase):
+    """Test the BaseTag class."""
+    def test_le_same_class(self):
+        """Test __le__ of two classes with same type."""
+        self.assertTrue(BaseTag(0x00000000) <= BaseTag(0x00000001))
+        self.assertTrue(BaseTag(0x00000001) <= BaseTag(0x00000001))
+        self.assertFalse(BaseTag(0x00000001) <= BaseTag(0x00000000))
+
+    def test_le_diff_class(self):
+        """Test __le__ of two classes with different type."""
+        self.assertTrue(BaseTag(0x00000000) <= 1)
+        self.assertTrue(BaseTag(0x00000001) <= 1)
+        self.assertFalse(BaseTag(0x00000001) <= 0)
+
+    def test_le_subclass(self):
+        """Test __le__ of two classes with one as a subclass."""
+        class BaseTagPlus(BaseTag): pass
+        self.assertTrue(BaseTagPlus(0x00000000) <= BaseTag(0x00000001))
+        self.assertTrue(BaseTagPlus(0x00000001) <= BaseTag(0x00000001))
+        self.assertFalse(BaseTagPlus(0x00000001) <= BaseTag(0x00000000))
+
+    def test_le_tuple(self):
+        """Test __le__ of tuple with BaseTag."""
+        self.assertTrue(BaseTag(0x00010001) <= (0x0001, 0x0002))
+        self.assertTrue(BaseTag(0x00010002) <= (0x0001, 0x0002))
+        self.assertFalse(BaseTag(0x00010002) <= (0x0001, 0x0001))
+
+    def test_le_raises(self):
+        """Test __le__ raises TypeError when comparing to non numeric."""
+        def test_raise():
+            BaseTag(0x00010002) <= '0x00010002'
+        self.assertRaises(TypeError, test_raise)
+
+    def test_lt_same_class(self):
+        """Test __lt__ of two classes with same type."""
+        self.assertTrue(BaseTag(0x00000000) < BaseTag(0x00000001))
+        self.assertFalse(BaseTag(0x00000001) < BaseTag(0x00000001))
+        self.assertFalse(BaseTag(0x00000001) < BaseTag(0x00000000))
+
+    def test_lt_diff_class(self):
+        """Test __lt__ of two classes with different type."""
+        self.assertTrue(BaseTag(0x00000000) < 1)
+        self.assertFalse(BaseTag(0x00000001) < 1)
+        self.assertFalse(BaseTag(0x00000001) < 0)
+
+    def test_lt_subclass(self):
+        """Test __lt__ of two classes with one as a subclass."""
+        class BaseTagPlus(BaseTag): pass
+        self.assertTrue(BaseTagPlus(0x00000000) < BaseTag(0x00000001))
+        self.assertFalse(BaseTagPlus(0x00000001) < BaseTag(0x00000001))
+        self.assertFalse(BaseTagPlus(0x00000001) < BaseTag(0x00000000))
+
+    def test_lt_tuple(self):
+        """Test __lt__ of tuple with BaseTag."""
+        self.assertTrue(BaseTag(0x00010001) < (0x0001, 0x0002))
+        self.assertFalse(BaseTag(0x00010002) < (0x0001, 0x0002))
+        self.assertFalse(BaseTag(0x00010002) < (0x0001, 0x0001))
+
+    def test_lt_raises(self):
+        """Test __lt__ raises TypeError when comparing to non numeric."""
+        def test_raise():
+            BaseTag(0x00010002) < '0x00010002'
+        self.assertRaises(TypeError, test_raise)
+
+    def test_ge_same_class(self):
+        """Test __ge__ of two classes with same type."""
+        self.assertFalse(BaseTag(0x00000000) >= BaseTag(0x00000001))
+        self.assertTrue(BaseTag(0x00000001) >= BaseTag(0x00000001))
+        self.assertTrue(BaseTag(0x00000001) >= BaseTag(0x00000000))
+
+    def test_ge_diff_class(self):
+        """Test __ge__ of two classes with different type."""
+        self.assertFalse(BaseTag(0x00000000) >= 1)
+        self.assertTrue(BaseTag(0x00000001) >= 1)
+        self.assertTrue(BaseTag(0x00000001) >= 0)
+
+    def test_ge_subclass(self):
+        """Test __ge__ of two classes with one as a subclass."""
+        class BaseTagPlus(BaseTag): pass
+        self.assertFalse(BaseTagPlus(0x00000000) >= BaseTag(0x00000001))
+        self.assertTrue(BaseTagPlus(0x00000001) >= BaseTag(0x00000001))
+        self.assertTrue(BaseTagPlus(0x00000001) >= BaseTag(0x00000000))
+
+    def test_ge_tuple(self):
+        """Test __ge__ of tuple with BaseTag."""
+        self.assertFalse(BaseTag(0x00010001) >= (0x0001, 0x0002))
+        self.assertTrue(BaseTag(0x00010002) >= (0x0001, 0x0002))
+        self.assertTrue(BaseTag(0x00010002) >= (0x0001, 0x0001))
+
+    def test_ge_raises(self):
+        """Test __ge__ raises TypeError when comparing to non numeric."""
+        def test_raise():
+            BaseTag(0x00010002) >= '0x00010002'
+        self.assertRaises(TypeError, test_raise)
+
+    def test_gt_same_class(self):
+        """Test __gt__ of two classes with same type."""
+        self.assertFalse(BaseTag(0x00000000) > BaseTag(0x00000001))
+        self.assertFalse(BaseTag(0x00000001) > BaseTag(0x00000001))
+        self.assertTrue(BaseTag(0x00000001) > BaseTag(0x00000000))
+
+    def test_gt_diff_class(self):
+        """Test __gt__ of two classes with different type."""
+        self.assertFalse(BaseTag(0x00000000) > 1)
+        self.assertFalse(BaseTag(0x00000001) > 1)
+        self.assertTrue(BaseTag(0x00000001) > 0)
+
+    def test_gt_subclass(self):
+        """Test __gt__ of two classes with one as a subclass."""
+        class BaseTagPlus(BaseTag): pass
+        self.assertFalse(BaseTagPlus(0x00000000) > BaseTag(0x00000001))
+        self.assertFalse(BaseTagPlus(0x00000001) > BaseTag(0x00000001))
+        self.assertTrue(BaseTagPlus(0x00000001) > BaseTag(0x00000000))
+
+    def test_gt_tuple(self):
+        """Test __gt__ of tuple with BaseTag."""
+        self.assertFalse(BaseTag(0x00010001) > (0x0001, 0x0002))
+        self.assertFalse(BaseTag(0x00010002) > (0x0001, 0x0002))
+        self.assertTrue(BaseTag(0x00010002) > (0x0001, 0x0001))
+
+    def test_gt_raises(self):
+        """Test __gt__ raises TypeError when comparing to non numeric."""
+        def test_raise():
+            BaseTag(0x00010002) > '0x00010002'
+        self.assertRaises(TypeError, test_raise)
+
+    def test_eq_same_class(self):
+        """Test __eq__ of two classes with same type."""
+        self.assertTrue(BaseTag(0x00000000) == BaseTag(0x00000000))
+        self.assertFalse(BaseTag(0x00000001) == BaseTag(0x00000000))
+
+    def test_eq_diff_class(self):
+        """Test __eq__ of two classes with different type."""
+        self.assertTrue(BaseTag(0x00000000) == 0)
+        self.assertFalse(BaseTag(0x00000001) == 0)
+
+    def test_eq_subclass(self):
+        """Test __eq__ of two classes with one as a subclass."""
+        class BaseTagPlus(BaseTag): pass
+        self.assertTrue(BaseTagPlus(0x00000000) == BaseTag(0x00000000))
+        self.assertFalse(BaseTagPlus(0x00000001) == BaseTag(0x00000000))
+
+    def test_eq_tuple(self):
+        """Test __eq__ of tuple with BaseTag."""
+        self.assertTrue(BaseTag(0x00010002) == (0x0001, 0x0002))
+        self.assertFalse(BaseTag(0x00010001) == (0x0001, 0x0002))
+
+    def test_eq_raises(self):
+        """Test __eq__ raises TypeError when comparing to non numeric."""
+        def test_raise():
+            BaseTag(0x00010002) == '0x00010002'
+        self.assertRaises(TypeError, test_raise)
+
+    def test_ne_same_class(self):
+        """Test __ne__ of two classes with same type."""
+        self.assertFalse(BaseTag(0x00000000) != BaseTag(0x00000000))
+        self.assertTrue(BaseTag(0x00000001) != BaseTag(0x00000000))
+
+    def test_ne_diff_class(self):
+        """Test __ne__ of two classes with different type."""
+        self.assertFalse(BaseTag(0x00000000) != 0)
+        self.assertTrue(BaseTag(0x00000001) != 0)
+
+    def test_ne_subclass(self):
+        """Test __ne__ of two classes with one as a subclass."""
+        class BaseTagPlus(BaseTag): pass
+        self.assertFalse(BaseTagPlus(0x00000000) != BaseTag(0x00000000))
+        self.assertTrue(BaseTagPlus(0x00000001) != BaseTag(0x00000000))
+
+    def test_ne_tuple(self):
+        """Test __ne__ of tuple with BaseTag."""
+        self.assertFalse(BaseTag(0x00010002) != (0x0001, 0x0002))
+        self.assertTrue(BaseTag(0x00010001) != (0x0001, 0x0002))
+
+    def test_ne_raises(self):
+        """Test __ne__ raises TypeError when comparing to non numeric."""
+        def test_raise():
+            BaseTag(0x00010002) != '0x00010002'
+        self.assertRaises(TypeError, test_raise)
+
+    def test_hash(self):
+        """Test hash of BaseTag class."""
+        self.assertEqual(hash(BaseTag(0x00010001)), hash(BaseTag(0x00010001)))
+        self.assertNotEqual(hash(BaseTag(0x00010001)), hash(BaseTag(0x00010002)))
+        self.assertNotEqual(hash(BaseTag(0x00020001)), hash(BaseTag(0x00010002)))
+
+    def test_str(self):
+        """Test str(BaseTag) produces correct value."""
+        self.assertEqual(str(BaseTag(0x00000000)), '(0000, 0000)')
+        self.assertEqual(str(BaseTag(0x00010002)), '(0001, 0002)')
+        self.assertEqual(str(BaseTag(0x10002000)), '(1000, 2000)')
+        self.assertEqual(str(BaseTag(0xFFFFFFFE)), '(ffff, fffe)')
+
+    def test_group(self):
+        """Test BaseTag.group returns correct values."""
+        self.assertEqual(BaseTag(0x00000001).group, 0x0000)
+        self.assertEqual(BaseTag(0x00020001).group, 0x0002)
+        self.assertEqual(BaseTag(0xFFFF0001).group, 0xFFFF)
+
+    def test_element(self):
+        """Test BaseTag.element returns correct values."""
+        self.assertEqual(BaseTag(0x00010000).element, 0x0000)
+        self.assertEqual(BaseTag(0x00010002).element, 0x0002)
+        self.assertEqual(BaseTag(0x0001FFFF).element, 0xFFFF)
+
+    def test_private(self):
+        """Test BaseTag.is_private returns correct values."""
+        self.assertTrue(BaseTag(0x00010001).is_private) # Odd groups private
+        self.assertFalse(BaseTag(0x00020001).is_private) # Even groups not private
+        self.assertFalse(BaseTag(0x00000001).is_private) # Group 0 not private
 
 
 class Values(unittest.TestCase):
@@ -57,36 +269,6 @@ class Values(unittest.TestCase):
     def testBadInts(self):
         """Tags constructed with > 8 bytes gives OverflowError......."""
         self.assertRaises(OverflowError, Tag, 0x123456789)
-
-
-class Comparisons(unittest.TestCase):
-    def setUp(self):
-        self.int1 = 0x300a00b0
-        self.tup1 = (0x300a, 0xb0)
-        self.tup3 = (0xFFFE, 0xFFFC)
-        self.t1 = Tag(self.int1)
-        self.t2 = Tag(self.tup1)
-        self.t3 = Tag(self.tup3)
-
-    def testCmpEq(self):
-        """Tags compare correctly (==)..............................."""
-        self.assertTrue(self.t1 == self.int1, "tag t1 was not equal to int1")
-        self.assertTrue(self.t1 == self.t2, "tag t1 did not equal other tag")
-        self.assertTrue(self.t1 == self.tup1, "tag t1 did not equal its tuple")
-
-    def testCmpNotEq(self):
-        self.assertTrue(self.t1 != self.t3, "Not equal comparison failed")
-
-    def testCmpLT(self):
-        """Tags compare correctly (<, >)............................."""
-        self.assertTrue(self.t1 < self.int1 + 1, "tag < failed")
-        self.assertTrue(self.int1 + 1 > self.t1, "int > tag failed")
-        self.assertTrue(self.t3 > self.t1, "'negative' int tag > other tag failed")
-
-    def testHash(self):
-        """Tags hash the same as an int.............................."""
-        self.assertTrue(hash(self.t1) == hash(self.int1))
-        self.assertTrue(hash(self.t2) == hash(self.int1))
 
 
 if __name__ == "__main__":

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -240,14 +240,24 @@ class TestTag(unittest.TestCase):
         self.assertEqual(Tag((0x22, 0xFF)), BaseTag(0x002200FF))
         self.assertEqual(Tag((14, 0xF)), BaseTag(0x000E000F))
         self.assertEqual(Tag((0x1000, 0x2000)), BaseTag(0x10002000))
+        self.assertEqual(Tag(('0x01', '0x02')), BaseTag(0x00010002))
 
         # Must be 2 tuple
         self.assertRaises(ValueError, Tag, (0x1000, 0x2000, 0x0030))
+        self.assertRaises(ValueError, Tag, ('0x10', '0x20', '0x03'))
         # Must be 32-bit
         self.assertRaises(OverflowError, Tag, (0xFFFF, 0xFFFF1))
+        self.assertRaises(OverflowError, Tag, ('0xFFFF', '0xFFFF1'))
         # Must be positive
         self.assertRaises(ValueError, Tag, (-1, 0))
         self.assertRaises(ValueError, Tag, (0, -1))
+        self.assertRaises(ValueError, Tag, ('0x0', '-0x1'))
+        self.assertRaises(ValueError, Tag, ('-0x1', '0x0'))
+        # Can't have second parameter
+        self.assertRaises(ValueError, Tag, (0x01, 0x02), 0x01)
+        self.assertRaises(ValueError, Tag, (0x01, 0x02), '0x01')
+        self.assertRaises(ValueError, Tag, ('0x01', '0x02'), '0x01')
+        self.assertRaises(ValueError, Tag, ('0x01', '0x02'), 0x01)
 
     def test_tag_single_list(self):
         """Test creating a Tag from a single list."""
@@ -255,16 +265,27 @@ class TestTag(unittest.TestCase):
         self.assertEqual(Tag([0x99, 0xFE]), BaseTag(0x009900FE))
         self.assertEqual(Tag([15, 0xE]), BaseTag(0x000F000E))
         self.assertEqual(Tag([0x1000, 0x2000]), BaseTag(0x10002000))
+        self.assertEqual(Tag(['0x01', '0x02']), BaseTag(0x00010002))
 
         # Must be 2 list
         self.assertRaises(ValueError, Tag, [0x1000, 0x2000, 0x0030])
+        self.assertRaises(ValueError, Tag, ['0x10', '0x20', '0x03'])
         self.assertRaises(ValueError, Tag, [0x1000])
+        self.assertRaises(ValueError, Tag, ['0x10'])
         # Must be 32-bit
         self.assertRaises(OverflowError, Tag, [65536, 0])
         self.assertRaises(OverflowError, Tag, [0, 65536])
+        self.assertRaises(OverflowError, Tag, ('0xFFFF', '0xFFFF1'))
         # Must be positive
         self.assertRaises(ValueError, Tag, [-1, 0])
         self.assertRaises(ValueError, Tag, [0, -1])
+        self.assertRaises(ValueError, Tag, ('0x0', '-0x1'))
+        self.assertRaises(ValueError, Tag, ('-0x1', '0x0'))
+        # Can't have second parameter
+        self.assertRaises(ValueError, Tag, [0x01, 0x02], 0x01)
+        self.assertRaises(ValueError, Tag, [0x01, 0x02], '0x01')
+        self.assertRaises(ValueError, Tag, ['0x01', '0x02'], '0x01')
+        self.assertRaises(ValueError, Tag, ['0x01', '0x02'], 0x01)
 
     def test_tag_single_str(self):
         """Test creating a Tag from a single str raises."""

--- a/tests/test_tag.py
+++ b/tests/test_tag.py
@@ -341,7 +341,7 @@ class TestTupleTag(unittest.TestCase):
     """Test the TupleTag method."""
     def test_tuple_tag(self):
         """Test quick tag construction with TupleTag."""
-        self.assertTrue(TupleTag((0xFFFF, 0xFFee)), BaseTag(0xFFFFFFEE))
+        self.assertEqual(TupleTag((0xFFFF, 0xFFee)), BaseTag(0xFFFFFFEE))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Added missing operators (`__le__`, `__gt__`, `__ge__`) to `BaseTag` (to ensure consistent behaviour with `__lt__` and `__eq__`) and refactored `__ne__`
* Added ability to use a single `str` when creating a `Tag`, i.e. `Tag('0x00100010')`
* `ValueError` now raised when attempting to create a negative `Tag`
* `ValueError` now raised when attempting to create a `Tag` using `Tag(0x10, '0x02')` (consistent with `ValueError` for `Tag('0x10', 0x20)`)
* Updated/expanded unit tests for tag module
* Minor docstring changes for `Dataset`