### PR TITLE
Add unit tests, updates for _write_file_meta_info

### DIFF
--- a/pydicom/filewriter.py
+++ b/pydicom/filewriter.py
@@ -468,51 +468,105 @@ def write_ATvalue(fp, data_element):
 
 
 def _write_file_meta_info(fp, meta_dataset):
-    """Write the dicom group 2 dicom storage File Meta Information to the file.
+    """Write the File Meta Information in `meta_dataset` to `fp`.
 
-    The file should already be positioned past the 128 byte preamble.
-    Raises ValueError if the required data_elements (elements 2,3,0x10,0x12)
-    are not in the dataset. If the dataset came from a file read with
-    read_file(), then the required data_elements should already be there.
+    The file-like `fp` should be positioned past the 128 byte preamble (which
+    should already have been written).
+
+    DICOM File Meta Information
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    From the DICOM standard, Part 10 Section 7.1, any DICOM file shall contain
+    a 128-byte preamble, a 4-byte DICOM prefix 'DICM' and (at a minimum) the
+    following Type 1 DICOM Elements (from Table 7.1-1):
+        * (0002,0000) FileMetaInformationGroupLength, UL, 4
+        * (0002,0001) FileMetaInformationVersion, OB, 2
+        * (0002,0002) MediaStorageSOPClassUID, UI, N
+        * (0002,0003) MediaStorageSOPInstanceUID, UI, N
+        * (0002,0010) TransferSyntaxUID, UI, N
+        * (0002,0012) ImplementationClassUID, UI, N
+
+    Of these (0002,0000) will be added/updated and (0002,0001) will be added
+    if not already present.
+
+    The following Type 3/1C Elements may also be present:
+        * (0002,0013) ImplementationVersionName, SH, N
+        * (0002,0016) SourceApplicationEntityTitle, AE, N
+        * (0002,0017) SendingApplicationEntityTitle, AE, N
+        * (0002,0018) ReceivingApplicationEntityTitle, AE, N
+        * (0002,0100) PrivateInformationCreatorUID, UI, N
+        * (0002,0102) PrivateInformation, OB, N
+
+    Encoding
+    ~~~~~~~~
+    The encoding of the File Meta Information shall be ExplicitVRLittleEndian.
+
+    Parameters
+    ----------
+    fp : file-like
+        The file-like to write the File Meta Information to.
+    meta_dataset : pydicom.dataset.Dataset
+        The File Meta Information DataElements.
+
+    Raises
+    ------
+    ValueError
+        If any of the required File Meta Information Elements are missing
+        from `meta_dataset`, with the exception of (0002,0000) and (0002,0001).
+    ValueError
+        If any non-Group 2 Elements are present in `meta_dataset`.
     """
     fp.write(b'DICM')
 
-    # File meta info is always LittleEndian, Explicit VR. After will change these
-    #    to the transfer syntax values set in the meta info
+    # File Meta Info is always Explicit VR Little Endian. The 'is_little_endian'
+    #   and 'is_implicit_VR' attributes will need to be set correctly after
+    #   the File Meta Info has been written.
     fp.is_little_endian = True
     fp.is_implicit_VR = False
 
-    if Tag((2, 1)) not in meta_dataset:
-        meta_dataset.add_new((2, 1), 'OB', b"\0\1")   # file meta information version
+    # Set a default value that will be updated later once we know the length
+    meta_dataset.FileMetaInformationGroupLength = 0
 
-    # Now check that required meta info tags are present:
+    if 'FileMetaInformationVersion' not in meta_dataset:
+        meta_dataset.FileMetaInformationVersion = b"\0\1"
+
+    # Check that no non-Group 2 Elements are present
+    for elem in meta_dataset:
+        if elem.tag.group != 0x0002:
+            raise ValueError("File meta information can only contain group 2 "
+                             "elements.")
+
+    # Check that required Elements are present
     missing = []
-    for element in [2, 3, 0x10, 0x12]:
-        if Tag((2, element)) not in meta_dataset:
-            missing.append(Tag((2, element)))
+    for element in [0x0002, 0x0003, 0x0010, 0x0012]:
+        if Tag(0x0002, element) not in meta_dataset:
+            missing.append(Tag(0x0002, element))
     if missing:
-        raise ValueError("Missing required tags {0} for file meta information".format(str(missing)))
+        raise ValueError("Missing required tags {0} for file meta "
+                         "information".format(str(missing)))
 
-    # Put in temp number for required group length, save current location to come back
-    meta_dataset[(2, 0)] = DataElement((2, 0), 'UL', 0)  # put 0 to start
-    group_length_data_element_size = 12  # !based on DICOM std ExplVR
-    group_length_tell = fp.tell()
-
-    # Write the file meta datset, including temp group length
-    length = write_dataset(fp, meta_dataset)
-    group_length = length - group_length_data_element_size  # counts from end of that
+    ## Write the File Meta Information elements to `fp`
+    #
+    # The first element is FileMetaInformationGroupLength and is always
+    #   required. It has a VR of 'UL' and so has a value that is
+    #   4 bytes fixed. The total length of this Element when encoded as
+    #   Explicit VR must therefore be 12 bytes.
+    end_group_length_elem = fp.tell() + 12
+    write_dataset(fp, meta_dataset)
 
     # Save end of file meta to go back to
     end_of_file_meta = fp.tell()
 
-    # Go back and write the actual group length
-    fp.seek(group_length_tell)
-    group_length_data_element = DataElement((2, 0), 'UL', group_length)
-    write_data_element(fp, group_length_data_element)
+    # Go back and write the FileMetaInformationGroupLength element with the
+    #   correct Group Length value, which is the number of bytes from the end
+    #   of the FileMetaInformationGroupLength element to the end of the
+    #   the File Meta Information elements
+    meta_dataset.FileMetaInformationGroupLength = \
+                                    end_of_file_meta - end_group_length_elem
+    fp.seek(end_group_length_elem - 12)
+    write_data_element(fp, meta_dataset[0x00020000])
 
-    # Return to end of file meta, ready to write remainder of the file
+    # Return to end of the file meta, ready to write remainder of the file
     fp.seek(end_of_file_meta)
-
 
 def write_file(filename, dataset, write_like_original=True):
     """Store a FileDataset to the filename specified.

--- a/tests/test_filewriter.py
+++ b/tests/test_filewriter.py
@@ -31,8 +31,8 @@ from pydicom.dataset import Dataset, FileDataset
 from pydicom.dataelem import DataElement
 from pydicom.filebase import DicomBytesIO
 from pydicom.filereader import read_file, read_dataset
-from pydicom.filewriter import write_data_element, write_dataset, \
-                               correct_ambiguous_vr
+from pydicom.filewriter import (write_data_element, write_dataset,
+                                correct_ambiguous_vr, _write_file_meta_info)
 from pydicom.multival import MultiValue
 from pydicom.sequence import Sequence
 from pydicom.util.hexutil import hex2bytes, bytes2hex
@@ -291,7 +291,7 @@ class WriteDataElementTests(unittest.TestCase):
         encoded_elem = self.encode_element(elem, False, True)
         ref_bytes = b'\x70\x00\x0d\x15\x4f\x44\x00\x00\x00\x00\x00\x00'
         self.assertEqual(encoded_elem, ref_bytes)
-        
+
     def test_write_OL_implicit_little(self):
         """Test writing elements with VR of OL works correctly."""
         # TrackPointIndexList
@@ -764,6 +764,124 @@ class ScratchWriteTests(unittest.TestCase):
 
         file_ds = FileDataset("test", self.ds)
         self.compare_write(std, file_ds)
+
+
+class TestWriteFileMetaInfo(unittest.TestCase):
+    """Unit tests for _write_file_meta_info."""
+    def setUp(self):
+        """Create an empty file-like for use in testing."""
+        self.fp = DicomBytesIO()
+
+    def test_bad_elements(self):
+        """Test that non-group 2 elements aren't written to the file meta."""
+        meta = Dataset()
+        meta.PatientID = '12345678'
+        meta.MediaStorageSOPClassUID = '1.1'
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        meta.TransferSyntaxUID = '1.3'
+        meta.ImplementationClassUID = '1.4'
+        self.assertRaises(ValueError, _write_file_meta_info, self.fp, meta)
+
+    def test_missing_elements(self):
+        """Test that missing required elements raises ValueError."""
+        meta = Dataset()
+        self.assertRaises(ValueError, _write_file_meta_info, self.fp, meta)
+        meta.MediaStorageSOPClassUID = '1.1'
+        self.assertRaises(ValueError, _write_file_meta_info, self.fp, meta)
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        self.assertRaises(ValueError, _write_file_meta_info, self.fp, meta)
+        meta.TransferSyntaxUID = '1.3'
+        self.assertRaises(ValueError, _write_file_meta_info, self.fp, meta)
+        meta.ImplementationClassUID = '1.4'
+        _write_file_meta_info(self.fp, meta)
+
+    def test_prefix(self):
+        """Test that the 'DICM' prefix is present."""
+        meta = Dataset()
+        meta.MediaStorageSOPClassUID = '1.1'
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        meta.TransferSyntaxUID = '1.3'
+        meta.ImplementationClassUID = '1.4'
+        _write_file_meta_info(self.fp, meta)
+
+        self.fp.seek(0)
+        prefix = self.fp.read(4)
+        self.assertEqual(prefix, b'DICM')
+
+    def test_group_length(self):
+        """Test that the value for FileMetaInformationGroupLength is OK."""
+        meta = Dataset()
+        meta.MediaStorageSOPClassUID = '1.1'
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        meta.TransferSyntaxUID = '1.3'
+        meta.ImplementationClassUID = '1.4'
+        _write_file_meta_info(self.fp, meta)
+
+        # 78 in total, - 4 for prefix, - 12 for group length = 62
+        self.fp.seek(12)
+        self.assertEqual(self.fp.read(4), b'\x3E\x00\x00\x00')
+
+    def test_group_length_updated(self):
+        """Test that FileMetaInformationGroupLength gets updated if present."""
+        meta = Dataset()
+        meta.FileMetaInformationGroupLength = 100 # Actual length
+        meta.MediaStorageSOPClassUID = '1.1'
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        meta.TransferSyntaxUID = '1.3'
+        meta.ImplementationClassUID = '1.4'
+        _write_file_meta_info(self.fp, meta)
+
+        self.fp.seek(12)
+        self.assertEqual(self.fp.read(4), b'\x3E\x00\x00\x00')
+        # Check original file meta is unchanged/updated
+        self.assertEqual(meta.FileMetaInformationGroupLength, 62)
+        self.assertEqual(meta.FileMetaInformationVersion, b'\x00\x01')
+        self.assertEqual(meta.MediaStorageSOPClassUID, '1.1')
+        self.assertEqual(meta.MediaStorageSOPInstanceUID, '1.2')
+        self.assertEqual(meta.TransferSyntaxUID, '1.3')
+        self.assertEqual(meta.ImplementationClassUID, '1.4')
+
+    def test_version(self):
+        """Test that the value for FileMetaInformationVersion is OK."""
+        meta = Dataset()
+        meta.MediaStorageSOPClassUID = '1.1'
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        meta.TransferSyntaxUID = '1.3'
+        meta.ImplementationClassUID = '1.4'
+        _write_file_meta_info(self.fp, meta)
+
+        self.fp.seek(16 + 12)
+        self.assertEqual(self.fp.read(2), b'\x00\x01')
+
+    def test_filelike_position(self):
+        """Test that the file-like's ending position is OK."""
+        # 4 bytes prefix
+        # 8 + 4 bytes FileMetaInformationGroupLength
+        # 12 + 2 bytes FileMetaInformationVersion
+        # 8 + 4 bytes MediaStorageSOPClassUID
+        # 8 + 4 bytes MediaStorageSOPInstanceUID
+        # 8 + 4 bytes TransferSyntaxUID
+        # 8 + 4 bytes ImplementationClassUID
+        # 78 bytes total
+        meta = Dataset()
+        meta.MediaStorageSOPClassUID = '1.1'
+        meta.MediaStorageSOPInstanceUID = '1.2'
+        meta.TransferSyntaxUID = '1.3'
+        meta.ImplementationClassUID = '1.4'
+        _write_file_meta_info(self.fp, meta)
+        self.assertEqual(self.fp.tell(), 78)
+
+        # 8 + 6 bytes ImplementationClassUID
+        # 80 bytes total, group length 64
+        self.fp.seek(0)
+        meta.ImplementationClassUID = '1.4.1'
+        _write_file_meta_info(self.fp, meta)
+        # Check File Meta length
+        self.assertEqual(self.fp.tell(), 80)
+        # Check Group Length
+        self.fp.seek(12)
+        self.assertEqual(self.fp.read(4), b'\x40\x00\x00\x00')
+        _write_file_meta_info(self.fp, meta)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Added unit tests for `_write_file_meta_info`.
* `ValueError` now raised if non Group 2 elements present in the File Meta.
* `file_meta.MetaInformationGroupLength` value now set correctly (issue #326).
* Refactored `_write_file_meta_info` to make it more readable.
* Expanded docstring