### PR TITLE
Make sure that Specific Character Set is always read

### DIFF
--- a/pydicom/filereader.py
+++ b/pydicom/filereader.py
@@ -233,7 +233,9 @@ def data_element_generator(fp, is_implicit_VR, is_little_endian,
         # Reading the value
         # First case (most common): reading a value with a defined length
         if length != 0xFFFFFFFF:
-            if defer_size is not None and length > defer_size:
+            # don't defer loading of Specific Character Set value as it is needed
+            # immediately to get the character encoding for other tags
+            if defer_size is not None and length > defer_size and tag != (0x08, 0x05):
                 # Flag as deferred by setting value to None, and skip bytes
                 value = None
                 logger_debug("Defer size exceeded. "

--- a/tests/test_filereader.py
+++ b/tests/test_filereader.py
@@ -407,6 +407,20 @@ class ReaderTests(unittest.TestCase):
         ds = read_file(fp, force=True)
         self.assertEqual(ds[0x7fe00010].VR, 'OB')
 
+    def test_long_specific_char_set(self):
+        """Test that specific character set is read even if it is longer than defer_size"""
+        ds = Dataset()
+
+        long_specific_char_set_value = ['ISO 2022IR 100'] * 9
+        ds.add(DataElement(0x00080005, 'CS', long_specific_char_set_value))
+
+        fp = BytesIO()
+        file_ds = FileDataset(fp, ds)
+        file_ds.save_as(fp)
+
+        ds = read_file(fp, defer_size=65, force=True)
+        self.assertEqual(ds[0x00080005].value, long_specific_char_set_value)
+
 
 class ReadDataElementTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
- prevents rare crash if reading data with defer_size less than Specific
Character Set value length