### PR TITLE
Repeater Group element improvements

### DIFF
--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -78,7 +78,7 @@ def dictionaryVR(tag):
 
 def dictionary_has_tag(tag):
     """Return True if the dicom dictionary has an entry for the given tag."""
-    return (tag in DicomDictionary)
+    return (tag in DicomDictionary or mask_match(tag) in RepeatersDictionary)
 
 
 def dictionary_keyword(tag):

--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -78,7 +78,11 @@ def dictionaryVR(tag):
 
 def dictionary_has_tag(tag):
     """Return True if the dicom dictionary has an entry for the given tag."""
-    return (tag in DicomDictionary or mask_match(tag) in RepeatersDictionary)
+    return (tag in DicomDictionary)
+
+def repeater_has_tag(tag):
+    """Return True if the DICOM repeaters dictionary has an entry for `tag`."""
+    return (mask_match(tag) in RepeatersDictionary)
 
 
 def dictionary_keyword(tag):

--- a/pydicom/datadict.py
+++ b/pydicom/datadict.py
@@ -80,10 +80,6 @@ def dictionary_has_tag(tag):
     """Return True if the dicom dictionary has an entry for the given tag."""
     return (tag in DicomDictionary)
 
-def repeater_has_tag(tag):
-    """Return True if the DICOM repeaters dictionary has an entry for `tag`."""
-    return (mask_match(tag) in RepeatersDictionary)
-
 
 def dictionary_keyword(tag):
     """Return the official DICOM standard (since 2011) keyword for the tag"""
@@ -214,6 +210,14 @@ def all_names_for_tag(tag):
         names.append(shortname)
     return names
 
+def repeater_has_tag(tag):
+    """Return True if the DICOM repeaters dictionary has an entry for `tag`."""
+    return (mask_match(tag) in RepeatersDictionary)
+
+def repeater_has_keyword(keyword):
+    """Return True if the DICOM repeaters element exists with `keyword`."""
+    repeater_keywords = [val[4] for val in RepeatersDictionary.values()]
+    return (keyword in repeater_keywords)
 
 # PRIVATE DICTIONARY handling
 # functions in analogy with those of main DICOM dict

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -16,7 +16,8 @@ from pydicom import compat
 from pydicom.config import logger
 from pydicom.datadict import (dictionary_has_tag, dictionary_description,
                               dictionary_keyword, dictionary_is_retired,
-                              private_dictionary_description, dictionaryVR)
+                              private_dictionary_description, dictionaryVR,
+                              repeater_has_tag)
 from pydicom.tag import Tag
 from pydicom.uid import UID
 import pydicom.valuerep  # don't import DS directly as can be changed by config
@@ -312,6 +313,8 @@ class DataElement(object):
     def description(self):
         """Return the DICOM dictionary name for the element."""
         if dictionary_has_tag(self.tag):
+            name = dictionary_description(self.tag)
+        elif repeater_has_tag(self.tag):
             name = dictionary_description(self.tag)
         elif self.tag.is_private:
             name = "Private tag data"  # default

--- a/pydicom/dataelem.py
+++ b/pydicom/dataelem.py
@@ -312,9 +312,7 @@ class DataElement(object):
 
     def description(self):
         """Return the DICOM dictionary name for the element."""
-        if dictionary_has_tag(self.tag):
-            name = dictionary_description(self.tag)
-        elif repeater_has_tag(self.tag):
+        if dictionary_has_tag(self.tag) or repeater_has_tag(self.tag):
             name = dictionary_description(self.tag)
         elif self.tag.is_private:
             name = "Private tag data"  # default

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1164,8 +1164,8 @@ class Dataset(dict):
             self[tag] = data_element
         elif repeater_has_keyword(name): # Check if `name` is repeaters element
             raise ValueError('{} is a DICOM repeating group element and must '
-                               'be added using the add_element() method.'
-                               .format(name))
+                             'be added using the add() or add_new() methods.'
+                             .format(name))
         else:  # name not in dicom dictionary - setting a non-dicom instance attribute
             # XXX note if user mis-spells a dicom data_element - no error!!!
             super(Dataset, self).__setattr__(name, value)

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -28,7 +28,7 @@ import sys
 from pydicom import compat
 from pydicom.charset import default_encoding, convert_encodings
 from pydicom.datadict import dictionaryVR
-from pydicom.datadict import tag_for_name, all_names_for_tag
+from pydicom.datadict import tag_for_name, all_names_for_tag, repeater_has_keyword
 from pydicom.tag import Tag, BaseTag
 from pydicom.dataelem import DataElement, DataElement_from_raw, RawDataElement
 from pydicom.uid import NotCompressedPixelTransferSyntaxes, UncompressedPixelTransferSyntaxes
@@ -1162,6 +1162,10 @@ class Dataset(dict):
                 data_element.value = value
             # Now have data_element - store it in this dict
             self[tag] = data_element
+        elif repeater_has_keyword(name): # Check if `name` is repeaters element
+            raise ValueError('{} is a DICOM repeating group element and must '
+                               'be added using the add_element() method.'
+                               .format(name))
         else:  # name not in dicom dictionary - setting a non-dicom instance attribute
             # XXX note if user mis-spells a dicom data_element - no error!!!
             super(Dataset, self).__setattr__(name, value)

--- a/tests/test_dataelem.py
+++ b/tests/test_dataelem.py
@@ -191,6 +191,11 @@ class DataElementTests(unittest.TestCase):
 
         self.assertRaises(TypeError, test_hash)
 
+    def test_repeater_str(self):
+        """Test a repeater group element displays the element name."""
+        elem = DataElement(0x60023000, 'OB', b'\x00')
+        self.assertTrue('Overlay Data' in elem.__str__())
+
 
 class RawDataElementTests(unittest.TestCase):
     def setUp(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -477,6 +477,14 @@ class DatasetTests(unittest.TestCase):
         dsp.test = 'ABCD'
         self.assertEqual(dsp.test, 'ABCD')
 
+    def test_add_repeater_element_keyword(self):
+        """Repeater using keyword to add repeater group elements raises ValueError."""
+        ds = Dataset()
+        def test():
+            ds.OverlayData = b'\x00'
+        self.assertRaises(ValueError, test)
+        
+
 
 class DatasetElementsTests(unittest.TestCase):
     """Test valid assignments of data elements"""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -477,13 +477,12 @@ class DatasetTests(unittest.TestCase):
         dsp.test = 'ABCD'
         self.assertEqual(dsp.test, 'ABCD')
 
-    def test_add_repeater_element_keyword(self):
+    def test_add_repeater_elem_by_keyword(self):
         """Repeater using keyword to add repeater group elements raises ValueError."""
         ds = Dataset()
         def test():
             ds.OverlayData = b'\x00'
         self.assertRaises(ValueError, test)
-        
 
 
 class DatasetElementsTests(unittest.TestCase):

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -7,7 +7,8 @@
 
 import unittest
 from pydicom.tag import Tag
-from pydicom.datadict import CleanName, all_names_for_tag, dictionary_description
+from pydicom.datadict import (CleanName, all_names_for_tag,
+                              dictionary_description, dictionary_has_tag)
 
 
 class DictTests(unittest.TestCase):
@@ -33,6 +34,16 @@ class DictTests(unittest.TestCase):
         """dicom_dictionary: Tags with "x" return correct dict info........"""
         self.assertEqual(dictionary_description(0x280400), 'Transform Label')
         self.assertEqual(dictionary_description(0x280410), 'Rows For Nth Order Coefficients')
+
+    def test_dict_has_tag(self):
+        """Test dictionary_has_tag"""
+        func = dictionary_has_tag
+        # Main dictionary
+        self.assertTrue(func(0x00100010))
+        self.assertFalse(func(0x11110010))
+        # Repeater dictioanry
+        self.assertTrue(func(0x60000010))
+        self.assertTrue(func(0x60020010))
 
 
 class PrivateDictTests(unittest.TestCase):

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -8,7 +8,8 @@
 import unittest
 from pydicom.tag import Tag
 from pydicom.datadict import (CleanName, all_names_for_tag,
-                              dictionary_description, dictionary_has_tag)
+                              dictionary_description, dictionary_has_tag,
+                              repeater_has_tag)
 
 
 class DictTests(unittest.TestCase):
@@ -37,13 +38,14 @@ class DictTests(unittest.TestCase):
 
     def test_dict_has_tag(self):
         """Test dictionary_has_tag"""
-        func = dictionary_has_tag
-        # Main dictionary
-        self.assertTrue(func(0x00100010))
-        self.assertFalse(func(0x11110010))
-        # Repeater dictioanry
-        self.assertTrue(func(0x60000010))
-        self.assertTrue(func(0x60020010))
+        self.assertTrue(dictionary_has_tag(0x00100010))
+        self.assertFalse(dictionary_has_tag(0x11110010))
+        
+    def test_repeater_has_tag(self):
+        """Test repeater_has_tag"""
+        self.assertTrue(repeater_has_tag(0x60000010))
+        self.assertTrue(repeater_has_tag(0x60020010))
+        self.assertFalse(repeater_has_tag(0x00100010))
 
 
 class PrivateDictTests(unittest.TestCase):

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -9,7 +9,7 @@ import unittest
 from pydicom.tag import Tag
 from pydicom.datadict import (CleanName, all_names_for_tag,
                               dictionary_description, dictionary_has_tag,
-                              repeater_has_tag)
+                              repeater_has_tag, repeater_has_keyword)
 
 
 class DictTests(unittest.TestCase):
@@ -46,6 +46,11 @@ class DictTests(unittest.TestCase):
         self.assertTrue(repeater_has_tag(0x60000010))
         self.assertTrue(repeater_has_tag(0x60020010))
         self.assertFalse(repeater_has_tag(0x00100010))
+
+    def test_repeater_has_keyword(self):
+        """Test repeater_has_keyword"""
+        self.assertTrue(repeater_has_keyword('OverlayData'))
+        self.assertFalse(repeater_has_keyword('PixelData'))
 
 
 class PrivateDictTests(unittest.TestCase):


### PR DESCRIPTION
* Element name added to `DataElement` string output for repeater group elements.
* Adding repeater group elements to `Dataset` via keyword (eg `ds.OverlayData = x`) now raises `ValueError` instead of creating a `Dataset` attribute.
* Added two `datadict.py` functions `repeater_has_keyword` and `repeater_has_tag`
* Unit tests for the above