### PR TITLE
Refactor Dataset.__getattr__ and pixel_array to remove multiple redundant exceptions

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -472,18 +472,17 @@ class Dataset(dict):
               DataElement's value. Otherwise returns the class attribute's value
               (if present).
         """
-        try:
-            tag = tag_for_keyword(name)
-            if tag is None: # `name` isn't a DICOM element keyword
-                raise AttributeError
-            tag = Tag(tag)
-            if tag not in self: # DICOM DataElement not in the Dataset
-                raise AttributeError
-            else:
-                return self[tag].value
-        except AttributeError:
+        tag = tag_for_keyword(name)
+        if tag is None: # `name` isn't a DICOM element keyword
             # Try the base class attribute getter (fix for issue 332)
             return super(Dataset, self).__getattribute__(name)
+        tag = Tag(tag)
+        if tag not in self: # DICOM DataElement not in the Dataset
+            # Try the base class attribute getter (fix for issue 332)
+            return super(Dataset, self).__getattribute__(name)
+        else:
+            return self[tag].value
+            
 
     @property
     def _character_set(self):
@@ -989,13 +988,7 @@ class Dataset(dict):
         numpy.ndarray
             The Pixel Data (7FE0,0010) as a NumPy ndarray.
         """
-        try:
-            return self._get_pixel_array()
-        except AttributeError:
-            t, e, tb = sys.exc_info()
-            val = PropertyError("AttributeError in pixel_array property: " +
-                                e.args[0])
-            compat.reraise(PropertyError, val, tb)
+        return self._get_pixel_array()
 
     # Format strings spec'd according to python string formatting options
     #    See http://docs.python.org/library/stdtypes.html#string-formatting-operations

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -59,9 +59,8 @@ class DatasetTests(unittest.TestCase):
         def callable_pixel_array():
             ds.pixel_array
 
-        msg = "AttributeError in pixel_array property: " + \
-            "'Dataset' object has no attribute 'TransferSyntaxUID'"
-        self.failUnlessExceptionArgs(msg, PropertyError, callable_pixel_array)
+        msg = "'Dataset' object has no attribute 'TransferSyntaxUID'"
+        self.failUnlessExceptionArgs(msg, AttributeError, callable_pixel_array)
 
     def test_attribute_error_in_property_correct_debug(self):
         """Test AttributeError in property raises correctly."""


### PR DESCRIPTION
Fix for catching redundant errors during exceptions as in [this traceback](https://groups.google.com/forum/#!msg/pydicom/TD1dY8r-oZA/yiXrG_ctAgAJ) and unit test updated to match.