### PR TITLE
Add Dataset slicing, unit tests, bug fixes

### DIFF
--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -237,6 +237,7 @@ class Dataset(dict):
             Dataset DataElement if present, None otherwise.
         """
         tag = tag_for_keyword(name)
+        # Test against None as (0000,0000) is a possible tag
         if tag is not None:
             return self[tag]
         return None
@@ -327,7 +328,7 @@ class Dataset(dict):
 
         Examples
         --------
-        Indexing
+        Indexing using DataElement tag
         >>> ds = Dataset()
         >>> ds.CommandGroupLength = 100
         >>> ds.PatientName = 'CITIZEN^Jan'
@@ -335,7 +336,7 @@ class Dataset(dict):
         >>> ds
         (0010, 0010) Patient's Name                      PN: 'CITIZEN^Jan'
 
-        Slicing
+        Slicing using DataElement tag
         >>> ds = Dataset()
         >>> ds.CommandGroupLength = 100
         >>> ds.SOPInstanceUID = '1.2.3'
@@ -371,10 +372,10 @@ class Dataset(dict):
         """
         # Force zip object into a list in case of python3. Also backwards
         # compatible
-        meths = set(list(zip(
-                    *inspect.getmembers(Dataset, inspect.isroutine)))[0])
-        props = set(list(zip(
-                    *inspect.getmembers(Dataset, inspect.isdatadescriptor)))[0])
+        meths = set(list(zip(*inspect.getmembers(Dataset,
+                                                 inspect.isroutine)))[0])
+        props = set(list(zip(*inspect.getmembers(Dataset,
+                                                 inspect.isdatadescriptor)))[0])
         dicom_names = set(self.dir())
         alldir = sorted(props | meths | dicom_names)
         return alldir
@@ -432,8 +433,6 @@ class Dataset(dict):
             # Compare Elements using values() and class variables using __dict__
             # Convert values() to a list for compatibility between
             #   python 2 and 3
-            #print('vals', list(self.values()) == list(other.values()))
-            #print('dict', self.__dict__ == other.__dict__)
             return (list(self.values()) == list(other.values()) and
                     self.__dict__ == other.__dict__)
 
@@ -529,6 +528,7 @@ class Dataset(dict):
 
         Examples
         --------
+        Indexing using DataElement tag
         >>> ds = Dataset()
         >>> ds.SOPInstanceUID = '1.2.3'
         >>> ds.PatientName = 'CITIZEN^Jan'
@@ -536,8 +536,7 @@ class Dataset(dict):
         >>> ds[0x00100010]
         'CITIZEN^Jan'
 
-        Slicing
-        ~~~~~~~
+        Slicing using DataElement tag
         All group 0x0010 elements in the dataset
         >>> ds[0x00100000:0x0011000]
         (0010, 0010) Patient's Name                      PN: 'CITIZEN^Jan'
@@ -1226,13 +1225,15 @@ class Dataset(dict):
 
         Raises
         ------
+        NotImplementedError
+            If `key` is a slice.
         ValueError
             If the `key` value doesn't match DataElement.tag.
         """
         if isinstance(key, slice):
             raise NotImplementedError('Slicing is not supported for setting '
                                       'Dataset elements.')
-        
+
         # OK if is subclass, e.g. DeferredDataElement
         if not isinstance(value, (DataElement, RawDataElement)):
             raise TypeError("Dataset contents must be DataElement instances.")

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -544,10 +544,7 @@ class Dataset(dict):
         (0010, 0020) Patient ID                          LO: '12345'
 
         All group 0x0002 elements in the dataset
-        >>> ds[(0x0002,0x0000):(0x0003,0x0000)]
-
-        All even tag elements in the dataset
-        >>> ds[::2]
+        >>> ds[(0x0002, 0x0000):(0x0003, 0x0000)]
 
         Parameters
         ----------
@@ -568,7 +565,6 @@ class Dataset(dict):
         if isinstance(key, slice):
             ds = Dataset()
             for tag in self._slice_dataset(key.start, key.stop, key.step):
-            #for tag in self._slice_dataset(key):
                 ds.add(self[tag])
             return ds
 
@@ -1233,6 +1229,10 @@ class Dataset(dict):
         ValueError
             If the `key` value doesn't match DataElement.tag.
         """
+        if isinstance(key, slice):
+            raise NotImplementedError('Slicing is not supported for setting '
+                                      'Dataset elements.')
+        
         # OK if is subclass, e.g. DeferredDataElement
         if not isinstance(value, (DataElement, RawDataElement)):
             raise TypeError("Dataset contents must be DataElement instances.")

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1270,7 +1270,7 @@ class Dataset(dict):
         list of pydicom.tag.Tag
             The tags in the Dataset that meet the conditions of the slice.
         """
-        if (start and start < 0) or (stop and stop < 0):
+        if (start and Tag(start) < 0) or (stop and Tag(stop) < 0):
             raise ValueError('Dataset slicing requires valid DICOM tags.')
 
         all_tags = sorted(self.keys())

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -237,7 +237,7 @@ class Dataset(dict):
             Dataset DataElement if present, None otherwise.
         """
         tag = tag_for_keyword(name)
-        if tag:
+        if tag is not None:
             return self[tag]
         return None
 
@@ -1270,14 +1270,14 @@ class Dataset(dict):
         list of pydicom.tag.Tag
             The tags in the Dataset that meet the conditions of the slice.
         """
-        # Check the starting/stopping Tags are valid
+        # Check the starting/stopping Tags are valid when used
         if start and Tag(start):
             pass
         if stop and Tag(stop):
             pass
 
-        # If the Dataset is empty, return an empty list
         all_tags = sorted(self.keys())
+        # If the Dataset is empty, return an empty list
         if not all_tags:
             return []
 

--- a/pydicom/dataset.py
+++ b/pydicom/dataset.py
@@ -1270,11 +1270,18 @@ class Dataset(dict):
         list of pydicom.tag.Tag
             The tags in the Dataset that meet the conditions of the slice.
         """
-        if (start and Tag(start) < 0) or (stop and Tag(stop) < 0):
-            raise ValueError('Dataset slicing requires valid DICOM tags.')
+        # Check the starting/stopping Tags are valid
+        if start and Tag(start):
+            pass
+        if stop and Tag(stop):
+            pass
 
+        # If the Dataset is empty, return an empty list
         all_tags = sorted(self.keys())
+        if not all_tags:
+            return []
 
+        # Ensure we have valid Tags when start/stop are None
         if start is None:
             start = all_tags[0]
         if stop is None:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -509,7 +509,7 @@ class DatasetTests(unittest.TestCase):
         self.assertRaises(ValueError, ds.__getitem__, slice(-1))
 
     def test_empty_slice(self):
-        """Tests Dataset slicing with empty Dataset"""
+        """Test Dataset slicing with empty Dataset."""
         ds = Dataset()
         self.assertEqual(ds[:], Dataset())
         self.assertRaises(ValueError, ds.__getitem__, slice(None,-1))
@@ -517,7 +517,6 @@ class DatasetTests(unittest.TestCase):
         self.assertRaises(ValueError, ds.__getitem__, slice(-1))
         self.assertRaises(NotImplementedError, ds.__setitem__,
                           slice(None), Dataset())
-        
 
     def test_getitem_slice(self):
         """Test Dataset.__getitem__ using slices."""
@@ -687,6 +686,32 @@ class DatasetTests(unittest.TestCase):
         self.assertTrue('CommandGroupLength' in ds)
         self.assertTrue('SkipFrameRangeFlag' in ds)
         self.assertTrue('PatientName' in ds)
+
+    def test_data_element(self):
+        """Test Dataset.data_element."""
+        ds = Dataset()
+        ds.CommandGroupLength = 120
+        ds.SkipFrameRangeFlag = 'TEST'
+        ds.add_new(0x00090001, 'PN', 'CITIZEN^1')
+        ds.BeamSequence = [Dataset()]
+        ds.BeamSequence[0].PatientName = 'ANON'
+        self.assertEqual(ds.data_element('CommandGroupLength'), ds[0x00000000])
+        self.assertEqual(ds.data_element('BeamSequence'), ds[0x300A00B0])
+
+    def test_iterall(self):
+        """Test Dataset.iterall"""
+        ds = Dataset()
+        ds.CommandGroupLength = 120
+        ds.SkipFrameRangeFlag = 'TEST'
+        ds.add_new(0x00090001, 'PN', 'CITIZEN^1')
+        ds.BeamSequence = [Dataset()]
+        ds.BeamSequence[0].PatientName = 'ANON'
+        elem_gen = ds.iterall()
+        self.assertEqual(ds.data_element('CommandGroupLength'), next(elem_gen))
+        self.assertEqual(ds.data_element('SkipFrameRangeFlag'), next(elem_gen))
+        self.assertEqual(ds[0x00090001], next(elem_gen))
+        self.assertEqual(ds.data_element('BeamSequence'), next(elem_gen))
+        self.assertEqual(ds.BeamSequence[0].data_element('PatientName'), next(elem_gen))
 
 
 class DatasetElementsTests(unittest.TestCase):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -483,6 +483,44 @@ class DatasetTests(unittest.TestCase):
             ds.OverlayData = b'\x00'
         self.assertRaises(ValueError, test)
 
+    def test_get_slice(self):
+        """Test Dataset[(gggg,eeee):(gggg,eeee)]"""
+        ds = Dataset()
+        ds.CommandGroupLength = 120 # 0000,0000
+        ds.CommandGroupLengthToEnd = 111 # 0000,0001
+        ds.Overlays = 12 # 0000,51B0
+        ds.LengthToEnd = 12 # 0008,0001
+        ds.add_new(0x00080002, 'PN', 'CITIZEN^2')
+        ds.add_new(0x00080003, 'PN', 'CITIZEN^3')
+        ds.add_new(0x00080004, 'PN', 'CITIZEN^4')
+        ds.add_new(0x00080005, 'PN', 'CITIZEN^5')
+        ds.add_new(0x00080006, 'PN', 'CITIZEN^6')
+        ds.add_new(0x00080007, 'PN', 'CITIZEN^7')
+        ds.add_new(0x00080008, 'PN', 'CITIZEN^8')
+        ds.add_new(0x00080009, 'PN', 'CITIZEN^9')
+        ds.add_new(0x00080010, 'PN', 'CITIZEN^10')
+        ds.SOPInstanceUID = '1.2.3.4' # 0008,0018
+        ds.SkipFrameRangeFlag = 'TEST' # 0008,9460
+        ds.PatientName = 'CITIZEN^Jan' # 0010,0010
+        ds.PatientID = '12345' # 0010,0010
+        ds.ExaminedBodyThickness = 1.223 # 0010,9431
+        ds.BeamSequence = [Dataset()] # 300A,00B0
+        ds.BeamSequence[0].PatientName = 'ANON'
+        #self.assertEqual(ds[:], ds)
+
+        print(ds[0x00010000:]) # All non group 0x0000
+
+        self.assertEqual(ds[0x00080000:0x0008FFFF], ds.group_dataset(0x0008)) # All group 0x0008
+        ref_ds = Dataset()
+        ref_ds.PatientName = 'CITIZEN^Jan'
+        self.assertEqual(ds[0x00100010:0x00100020], ref_ds) # Dataset with PatientName element only
+
+        print(ds[0x00080000:0x00100000:2]) # Every 2nd element in group 0x0008
+        print(ds[:0x00080000]) # < group 0x0008
+        print(ds[:0x0008FFFF:2]) # <= group 0x0008, step 2
+
+        print(ds[(0x0010,0000):])
+
 
 class DatasetElementsTests(unittest.TestCase):
     """Test valid assignments of data elements"""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -611,6 +611,34 @@ class DatasetTests(unittest.TestCase):
         self.assertFalse(0x00090010 in ds)
         self.assertTrue('PatientName' in ds)
 
+    def test_group_dataset(self):
+        """Test Dataset.group_dataset"""
+        ds = Dataset()
+        ds.CommandGroupLength = 120 # 0000,0000
+        ds.CommandLengthToEnd = 111 # 0000,0001
+        ds.Overlays = 12 # 0000,51B0
+        ds.LengthToEnd = 12 # 0008,0001
+        ds.SOPInstanceUID = '1.2.3.4' # 0008,0018
+        ds.SkipFrameRangeFlag = 'TEST' # 0008,9460
+
+        # Test getting group 0x0000
+        group0000 = ds.group_dataset(0x0000)
+        self.assertTrue('CommandGroupLength' in group0000)
+        self.assertTrue('CommandLengthToEnd' in group0000)
+        self.assertTrue('Overlays' in group0000)
+        self.assertFalse('LengthToEnd' in group0000)
+        self.assertFalse('SOPInstanceUID' in group0000)
+        self.assertFalse('SkipFrameRangeFlag' in group0000)
+
+        # Test getting group 0x0008
+        group0000 = ds.group_dataset(0x0008)
+        self.assertFalse('CommandGroupLength' in group0000)
+        self.assertFalse('CommandLengthToEnd' in group0000)
+        self.assertFalse('Overlays' in group0000)
+        self.assertTrue('LengthToEnd' in group0000)
+        self.assertTrue('SOPInstanceUID' in group0000)
+        self.assertTrue('SkipFrameRangeFlag' in group0000)
+
 
 class DatasetElementsTests(unittest.TestCase):
     """Test valid assignments of data elements"""


### PR DESCRIPTION
* Fixes for `Dataset.data_element` and `Dataset.__contains__` not handing (0000,0000) properly.
* Add unit tests for `Dataset.iterall`, `Dataset.data_element`, `Dataset.remove_private_tags`, `Dataset.get_item`, `Dataset.group_dataset`.
* Add Dataset slicing using element tags to `Dataset.__getitem__` and `Dataset.__delitem__`, unit testing:
```python
ds = read_file('file-in.dcm')
new_ds = ds[:(0x0001,0x0000)] # Get all group 0000 elements
new_ds = ds[0x00080000:0x00080012] # Get all elements from (0008,0000) to (0008,0012)
del ds[:(0x0001,0x0000)] # Delete all group 0000 elements
```
